### PR TITLE
로그인 구현

### DIFF
--- a/member/src/main/java/ddalkak/member/common/config/SecurityConfig.java
+++ b/member/src/main/java/ddalkak/member/common/config/SecurityConfig.java
@@ -1,14 +1,69 @@
 package ddalkak.member.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ddalkak.member.common.filter.handler.CustomAuthenticationFailureHandler;
+import ddalkak.member.common.filter.CustomUsernamePasswordAuthFilter;
+import ddalkak.member.common.filter.handler.CustomAuthenticationSuccessHandler;
+import ddalkak.member.service.JwtProvider;
+import ddalkak.member.service.RefreshTokenService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final ObjectMapper objectMapper;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
+        CustomUsernamePasswordAuthFilter filter = new CustomUsernamePasswordAuthFilter();
+        filter.setAuthenticationManager(authenticationManager);
+        filter.setAuthenticationSuccessHandler(successHandler());
+        filter.setAuthenticationFailureHandler(failureHandler());
+
+        return http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .addFilterAt(filter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public AuthenticationSuccessHandler successHandler() {
+        return new CustomAuthenticationSuccessHandler(jwtProvider, refreshTokenService, objectMapper);
+    }
+
+    @Bean
+    public AuthenticationFailureHandler failureHandler() {
+        return new CustomAuthenticationFailureHandler();
     }
 }

--- a/member/src/main/java/ddalkak/member/common/filter/CustomUsernamePasswordAuthFilter.java
+++ b/member/src/main/java/ddalkak/member/common/filter/CustomUsernamePasswordAuthFilter.java
@@ -1,0 +1,34 @@
+package ddalkak.member.common.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ddalkak.member.dto.request.LoginRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+public class CustomUsernamePasswordAuthFilter extends UsernamePasswordAuthenticationFilter {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public CustomUsernamePasswordAuthFilter() {
+        super.setFilterProcessesUrl("/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try (InputStream inputStream = request.getInputStream()) {
+            LoginRequest loginRequest = objectMapper.readValue(inputStream, LoginRequest.class);
+            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(loginRequest.email(), loginRequest.password());
+            return getAuthenticationManager().authenticate(authenticationToken);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/member/src/main/java/ddalkak/member/common/filter/handler/CustomAuthenticationFailureHandler.java
+++ b/member/src/main/java/ddalkak/member/common/filter/handler/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,15 @@
+package ddalkak.member.common.filter.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/member/src/main/java/ddalkak/member/common/filter/handler/CustomAuthenticationSuccessHandler.java
+++ b/member/src/main/java/ddalkak/member/common/filter/handler/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,84 @@
+package ddalkak.member.common.filter.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ddalkak.member.domain.CustomUserDetails;
+import ddalkak.member.domain.Member;
+import ddalkak.member.dto.jwt.Jwt;
+import ddalkak.member.dto.jwt.RequiredClaims;
+import ddalkak.member.dto.response.LoginResponse;
+import ddalkak.member.service.JwtProvider;
+import ddalkak.member.service.RefreshTokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import java.io.IOException;
+import java.time.Duration;
+
+@RequiredArgsConstructor
+public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) {
+        Member loginMember = extractMember(authentication);
+        Jwt jwt = generateJwt(loginMember);
+        try {
+            refreshTokenService.saveOrUpdate(loginMember, jwt.refreshToken());
+            setLoginSuccessResponse(response, loginMember, jwt);
+        } catch (Exception e) {
+            setDBTransactionFailureResponse(response);
+        }
+    }
+
+    private void setDBTransactionFailureResponse(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    private void setLoginSuccessResponse(HttpServletResponse response, Member loginMember, Jwt jwt) throws IOException {
+        response.setHeader(HttpHeaders.AUTHORIZATION, jwt.grantType() + " " + jwt.accessToken());
+        response.setHeader(HttpHeaders.SET_COOKIE, createRefreshTokenCookie(jwt));
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), createLoginResponse(loginMember));
+    }
+
+    private LoginResponse createLoginResponse(Member member) {
+        return LoginResponse.builder()
+                .memberId(member.getMemberId())
+                .email(member.getEmail())
+                .name(member.getName())
+                .build();
+    }
+
+    private Jwt generateJwt(Member loginMember) {
+        return jwtProvider.valueOf(new RequiredClaims(
+                loginMember.getMemberId(),
+                loginMember.getName(),
+                loginMember.getRoles()));
+    }
+
+    private String createRefreshTokenCookie(Jwt jwt) {
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", jwt.refreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(Duration.ofDays(14))
+                .build();
+        return cookie.toString();
+    }
+
+    private Member extractMember(Authentication authentication) {
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getMember();
+    }
+}

--- a/member/src/main/java/ddalkak/member/domain/CustomUserDetails.java
+++ b/member/src/main/java/ddalkak/member/domain/CustomUserDetails.java
@@ -1,0 +1,40 @@
+package ddalkak.member.domain;
+
+import ddalkak.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return member.getRoles().stream()
+                .map(role -> new SimpleGrantedAuthority(role.getKey()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    // 기본 설정, return true
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/member/src/main/java/ddalkak/member/domain/Member.java
+++ b/member/src/main/java/ddalkak/member/domain/Member.java
@@ -11,14 +11,13 @@ import java.util.List;
 @Entity
 @Getter
 public class Member {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
     @Column(unique = true)
     private String email;
     private String password;
     private String name;
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
     @Builder.Default
     private List<MemberType> roles = new ArrayList<>();

--- a/member/src/main/java/ddalkak/member/domain/MemberType.java
+++ b/member/src/main/java/ddalkak/member/domain/MemberType.java
@@ -1,6 +1,13 @@
 package ddalkak.member.domain;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
 public enum MemberType {
-    USER,
-    ADMIN
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String key;
 }

--- a/member/src/main/java/ddalkak/member/domain/RefreshToken.java
+++ b/member/src/main/java/ddalkak/member/domain/RefreshToken.java
@@ -1,0 +1,29 @@
+package ddalkak.member.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+
+@Entity
+public class RefreshToken {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long tokenId;
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+    @Column(length = 1000)
+    private String token;
+
+    public RefreshToken() {
+
+    }
+
+    @Builder
+    public RefreshToken(Member member, String token) {
+        this.member = member;
+        this.token = token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/member/src/main/java/ddalkak/member/dto/jwt/Jwt.java
+++ b/member/src/main/java/ddalkak/member/dto/jwt/Jwt.java
@@ -1,0 +1,9 @@
+package ddalkak.member.dto.jwt;
+
+import lombok.Builder;
+
+@Builder
+public record Jwt(String grantType,
+                  String accessToken,
+                  String refreshToken) {
+}

--- a/member/src/main/java/ddalkak/member/dto/jwt/RequiredClaims.java
+++ b/member/src/main/java/ddalkak/member/dto/jwt/RequiredClaims.java
@@ -1,0 +1,10 @@
+package ddalkak.member.dto.jwt;
+
+import ddalkak.member.domain.MemberType;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RequiredClaims(Long memberId, String name, List<MemberType> roles) {
+}

--- a/member/src/main/java/ddalkak/member/dto/request/LoginRequest.java
+++ b/member/src/main/java/ddalkak/member/dto/request/LoginRequest.java
@@ -1,0 +1,5 @@
+package ddalkak.member.dto.request;
+
+public record LoginRequest(String email,
+                           String password) {
+}

--- a/member/src/main/java/ddalkak/member/dto/response/LoginResponse.java
+++ b/member/src/main/java/ddalkak/member/dto/response/LoginResponse.java
@@ -1,0 +1,9 @@
+package ddalkak.member.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record LoginResponse(Long memberId,
+                            String name,
+                            String email) {
+}

--- a/member/src/main/java/ddalkak/member/repository/member/DataJpaMemberRepository.java
+++ b/member/src/main/java/ddalkak/member/repository/member/DataJpaMemberRepository.java
@@ -1,4 +1,4 @@
-package ddalkak.member.repository;
+package ddalkak.member.repository.member;
 
 import ddalkak.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/member/src/main/java/ddalkak/member/repository/member/JpaMemberRepository.java
+++ b/member/src/main/java/ddalkak/member/repository/member/JpaMemberRepository.java
@@ -1,4 +1,4 @@
-package ddalkak.member.repository;
+package ddalkak.member.repository.member;
 
 import ddalkak.member.domain.Member;
 import lombok.RequiredArgsConstructor;

--- a/member/src/main/java/ddalkak/member/repository/member/MemberRepository.java
+++ b/member/src/main/java/ddalkak/member/repository/member/MemberRepository.java
@@ -1,4 +1,4 @@
-package ddalkak.member.repository;
+package ddalkak.member.repository.member;
 
 import ddalkak.member.domain.Member;
 

--- a/member/src/main/java/ddalkak/member/repository/refreshtoken/DataJpaRefreshTokenRepository.java
+++ b/member/src/main/java/ddalkak/member/repository/refreshtoken/DataJpaRefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package ddalkak.member.repository.refreshtoken;
+
+import ddalkak.member.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DataJpaRefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByMember_MemberId(Long memberId);
+}

--- a/member/src/main/java/ddalkak/member/repository/refreshtoken/JpaRefreshTokenRepository.java
+++ b/member/src/main/java/ddalkak/member/repository/refreshtoken/JpaRefreshTokenRepository.java
@@ -1,0 +1,23 @@
+package ddalkak.member.repository.refreshtoken;
+
+import ddalkak.member.domain.RefreshToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaRefreshTokenRepository implements RefreshTokenRepository {
+    private final DataJpaRefreshTokenRepository dataJpaRepository;
+
+    @Override
+    public RefreshToken save(RefreshToken token) {
+        return dataJpaRepository.save(token);
+    }
+
+    @Override
+    public Optional<RefreshToken> findByMemberId(Long memberId) {
+        return dataJpaRepository.findByMember_MemberId(memberId);
+    }
+}

--- a/member/src/main/java/ddalkak/member/repository/refreshtoken/RefreshTokenRepository.java
+++ b/member/src/main/java/ddalkak/member/repository/refreshtoken/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package ddalkak.member.repository.refreshtoken;
+
+import ddalkak.member.domain.RefreshToken;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+    RefreshToken save(RefreshToken token);
+
+    Optional<RefreshToken> findByMemberId(Long memberId);
+}

--- a/member/src/main/java/ddalkak/member/service/AuthService.java
+++ b/member/src/main/java/ddalkak/member/service/AuthService.java
@@ -1,0 +1,23 @@
+package ddalkak.member.service;
+
+import ddalkak.member.domain.CustomUserDetails;
+import ddalkak.member.domain.Member;
+import ddalkak.member.repository.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+        return new CustomUserDetails(member);
+    }
+}

--- a/member/src/main/java/ddalkak/member/service/JwtProvider.java
+++ b/member/src/main/java/ddalkak/member/service/JwtProvider.java
@@ -1,0 +1,51 @@
+package ddalkak.member.service;
+
+import ddalkak.member.dto.jwt.Jwt;
+import ddalkak.member.dto.jwt.RequiredClaims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@Slf4j
+public class JwtProvider {
+    private final PrivateKey privateKey;
+    public static final long ONE_HOUR = 1000L * 60 * 60;
+    public static final long TWO_WEEKS = 1000L * 60 * 60 * 24 * 14;
+
+    public JwtProvider(@Value("${jwt.private_key}") String encodedPrivateKey) throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+
+        byte[] decodePrivateKey = Base64.getDecoder().decode(encodedPrivateKey);
+        PKCS8EncodedKeySpec privateSpec = new PKCS8EncodedKeySpec(decodePrivateKey);
+        this.privateKey = keyFactory.generatePrivate(privateSpec);
+    }
+
+    public Jwt valueOf(RequiredClaims claims) {
+        long now = (new Date()).getTime();
+        String accessToken = Jwts.builder()
+                .setSubject(String.valueOf(claims.memberId()))
+                .claim("name", claims.name())
+                .claim("roles", claims.roles())
+                .setExpiration(new Date(now + ONE_HOUR))
+                .signWith(privateKey, SignatureAlgorithm.RS256)
+                .compact();
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + TWO_WEEKS))
+                .signWith(privateKey, SignatureAlgorithm.RS256)
+                .compact();
+        return Jwt.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/member/src/main/java/ddalkak/member/service/MemberService.java
+++ b/member/src/main/java/ddalkak/member/service/MemberService.java
@@ -4,7 +4,7 @@ import ddalkak.member.domain.Member;
 import ddalkak.member.dto.request.SignUpRequest;
 import ddalkak.member.common.exception.DuplicatedEmailException;
 import ddalkak.member.common.exception.errorcode.ErrorCode;
-import ddalkak.member.repository.MemberRepository;
+import ddalkak.member.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/member/src/main/java/ddalkak/member/service/RefreshTokenService.java
+++ b/member/src/main/java/ddalkak/member/service/RefreshTokenService.java
@@ -1,0 +1,26 @@
+package ddalkak.member.service;
+
+import ddalkak.member.domain.Member;
+import ddalkak.member.domain.RefreshToken;
+import ddalkak.member.repository.refreshtoken.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public void saveOrUpdate(final Member member, final String refreshToken) {
+        refreshTokenRepository.findByMemberId(member.getMemberId())
+                .ifPresentOrElse(
+                        existToken -> existToken.setToken(refreshToken),
+                        () -> refreshTokenRepository.save(RefreshToken.builder()
+                                .member(member)
+                                .token(refreshToken)
+                                .build())
+                );
+    }
+}

--- a/member/src/test/java/ddalkak/member/SpringSecurityLoginTest.java
+++ b/member/src/test/java/ddalkak/member/SpringSecurityLoginTest.java
@@ -1,0 +1,92 @@
+package ddalkak.member;
+
+import com.google.gson.Gson;
+import ddalkak.member.domain.Member;
+import ddalkak.member.dto.request.LoginRequest;
+import ddalkak.member.dto.request.SignUpRequest;
+import ddalkak.member.repository.refreshtoken.RefreshTokenRepository;
+import ddalkak.member.service.MemberService;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class SpringSecurityLoginTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Test
+    void 로그인_성공() throws Exception {
+        //given
+        SignUpRequest signUpRequest = new SignUpRequest("홍길동", "test@exam.com", "password");
+        Member member = memberService.signup(signUpRequest);
+        LoginRequest loginRequest = new LoginRequest("test@exam.com", "password");
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new Gson().toJson(loginRequest))
+        );
+
+        //then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Authorization"))
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, Matchers.containsString("refreshToken")))
+                .andExpect(jsonPath("$.memberId").value(member.getMemberId()))
+                .andExpect(jsonPath("$.name").value(member.getName()))
+                .andExpect(jsonPath("$.email").value(member.getEmail()));
+        assertThat(refreshTokenRepository.findByMemberId(member.getMemberId())).isPresent();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideLoginRequest")
+    void 로그인_실패(SignUpRequest signUpRequest, LoginRequest loginRequest) throws Exception {
+        //given
+        memberService.signup(signUpRequest);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new Gson().toJson(loginRequest))
+        );
+
+        //then
+        resultActions.andExpect(status().isUnauthorized());
+    }
+
+    static Stream<Arguments> provideLoginRequest() {
+        return Stream.of(
+                Arguments.of(new SignUpRequest("ex", "test1@exam.com", "password"),
+                        new LoginRequest("test1@exam.com", "invalid_password")),
+                Arguments.of(new SignUpRequest("ex", "test2@exam.com", "password"),
+                        new LoginRequest("invalid@exam.com", "password"))
+        );
+    }
+}

--- a/member/src/test/java/ddalkak/member/repository/JpaMemberRepositoryTest.java
+++ b/member/src/test/java/ddalkak/member/repository/JpaMemberRepositoryTest.java
@@ -2,6 +2,8 @@ package ddalkak.member.repository;
 
 import ddalkak.member.domain.Member;
 import ddalkak.member.dto.request.SignUpRequest;
+import ddalkak.member.repository.member.DataJpaMemberRepository;
+import ddalkak.member.repository.member.JpaMemberRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/member/src/test/java/ddalkak/member/service/MemberServiceTest.java
+++ b/member/src/test/java/ddalkak/member/service/MemberServiceTest.java
@@ -3,7 +3,7 @@ package ddalkak.member.service;
 import ddalkak.member.domain.Member;
 import ddalkak.member.dto.request.SignUpRequest;
 import ddalkak.member.common.exception.DuplicatedEmailException;
-import ddalkak.member.repository.MemberRepository;
+import ddalkak.member.repository.member.MemberRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/member/src/test/resources/application-test.yml
+++ b/member/src/test/resources/application-test.yml
@@ -4,6 +4,7 @@ spring:
   config:
     activate:
       on-profile: test
+    import: aws-parameterstore:/config/member_test/
   datasource:
     url: jdbc:h2:mem:test;MODE=MySQL
     driver-class-name: org.h2.Driver
@@ -14,3 +15,6 @@ spring:
     hibernate:
       ddl-auto: create-drop
     database-platform: org.hibernate.dialect.H2Dialect
+
+jwt:
+  private_key: ${jwt_private_key}


### PR DESCRIPTION
- spring security를 통한 로그인
- access 토큰은 Authorization 헤더로 응답
- refresh 토큰은 HttpOnly Secure 쿠키에 저장
- 서버측에서는 RDB에 refresh 토큰 저장(구조 변경 가능성 염두)
- 통합 테스트를 통해 동작 확인했고 Postman으로도 동작 확인해봤습니다.