### PR TITLE
snow flake 스타일의 유일 ID 생성기 구현

### DIFF
--- a/member/src/main/java/ddalkak/member/service/auth/CustomAuthenticationFailureHandler.java
+++ b/member/src/main/java/ddalkak/member/service/auth/CustomAuthenticationFailureHandler.java
@@ -1,4 +1,4 @@
-package ddalkak.member.common.filter.handler;
+package ddalkak.member.service.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import ddalkak.member.common.exception.TxFailureException;
@@ -6,7 +6,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;

--- a/member/src/main/java/ddalkak/member/service/auth/CustomAuthenticationSuccessHandler.java
+++ b/member/src/main/java/ddalkak/member/service/auth/CustomAuthenticationSuccessHandler.java
@@ -1,4 +1,4 @@
-package ddalkak.member.common.filter.handler;
+package ddalkak.member.service.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import ddalkak.member.domain.CustomUserDetails;
@@ -7,8 +7,7 @@ import ddalkak.member.dto.event.InternalLoginEvent;
 import ddalkak.member.dto.jwt.Jwt;
 import ddalkak.member.dto.jwt.RequiredClaims;
 import ddalkak.member.dto.response.LoginResponse;
-import ddalkak.member.service.auth.JwtProvider;
-import ddalkak.member.service.UniqueIdGenerator;
+import ddalkak.member.service.event.UniqueIdGenerator;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;

--- a/member/src/main/java/ddalkak/member/service/event/SnowFlakeIdGenerator.java
+++ b/member/src/main/java/ddalkak/member/service/event/SnowFlakeIdGenerator.java
@@ -1,0 +1,61 @@
+package ddalkak.member.service.event;
+
+import org.springframework.stereotype.Component;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+@Component
+public class SnowFlakeIdGenerator implements UniqueIdGenerator{
+    private static final long EPOCH = 1735689600000L; // 2025-01-01 UTC
+    private static final int WORKER_BITS = 10;
+    private static final int SEQ_BITS = 12;
+    private static final int MAX_SEQ = 4095;
+
+    private long machineId;
+    private long lastMillis = -1L;
+    private long sequence = 0L;
+
+    public SnowFlakeIdGenerator() {
+        this.machineId = resolveMachineId();
+    }
+
+    /**
+     * 64비트 SnowFlake 스타일의 Id를 생성 <br>
+     * [timestamp(41bits)][machineId(10bits)][sequence(12bits)] <br>
+     * 같은 timestamp, 같은 호스트 머신에서 밀리초당 최대 4095개의 id 생성 가능
+     * @return uniqueId
+     */
+    @Override
+    public synchronized Long generate() {
+        long now = System.currentTimeMillis();
+        if (now < lastMillis) {
+            throw new IllegalStateException("Clock move backwards, refuse generating Id");
+        }
+        if (now == lastMillis) {
+            sequence = (sequence + 1) & MAX_SEQ;
+            if (sequence == 0) { // 오버플로우 발생, 다음 ms까지 대기
+                while (now == lastMillis) {
+                    now = System.currentTimeMillis();
+                }
+            }
+        } else {
+            sequence = 0;
+        }
+        lastMillis = now;
+        return ((now - EPOCH) << WORKER_BITS + SEQ_BITS) | (machineId << SEQ_BITS) | sequence;
+    }
+
+    private long resolveMachineId()  {
+        InetAddress address = null;
+        try {
+            address = InetAddress.getLocalHost();
+        } catch (UnknownHostException e) {
+            throw new IllegalStateException("UnknownHost, refuse generating eventId");
+        }
+        byte[] ip = address.getAddress();
+        int rawHash = Arrays.hashCode(ip);
+        return rawHash & 0x3FF; // 하위 10bits만 보존 (0x3FF = 1111111111)
+    }
+}

--- a/member/src/main/java/ddalkak/member/service/event/UniqueIdGenerator.java
+++ b/member/src/main/java/ddalkak/member/service/event/UniqueIdGenerator.java
@@ -1,4 +1,4 @@
-package ddalkak.member.service;
+package ddalkak.member.service.event;
 
 public interface UniqueIdGenerator {
     Long generate();


### PR DESCRIPTION
- 64비트의 고정 길이, 앞에서부터 타임스탬프(41 bits), 머신ID(10 bits), 시퀀스(12 bits)로 구성
- 동일한 타임스탬프, 머신ID 기준 밀리초당 최대 4095개의 유일 ID 생성 가능
- 비트 마스킹을 활용해 구현
