### PR TITLE
Jwt 재발급을 통한 로그인 연장 기능 구현

### DIFF
--- a/member/src/main/java/ddalkak/member/common/exception/RefreshTokenNotFoundException.java
+++ b/member/src/main/java/ddalkak/member/common/exception/RefreshTokenNotFoundException.java
@@ -1,0 +1,9 @@
+package ddalkak.member.common.exception;
+
+import ddalkak.member.common.exception.errorcode.ErrorCode;
+
+public class RefreshTokenNotFoundException extends BusinessException {
+    public RefreshTokenNotFoundException() {
+        super(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+    }
+}

--- a/member/src/main/java/ddalkak/member/common/exception/errorcode/ErrorCode.java
+++ b/member/src/main/java/ddalkak/member/common/exception/errorcode/ErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다.");
+    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "로그인 정보를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/member/src/main/java/ddalkak/member/controller/AuthController.java
+++ b/member/src/main/java/ddalkak/member/controller/AuthController.java
@@ -1,0 +1,45 @@
+package ddalkak.member.controller;
+
+import ddalkak.member.dto.jwt.Jwt;
+import ddalkak.member.service.auth.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Duration;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    /**
+     * 앞 단의 인가 서버에서 refreshToken의 만료 기간 등 유효성 검사는 마치고 넘어온 상황.
+     * DB에서 refreshToken 존재 유무를 확인하고, 새로운 AccessToken을 만들어 반환
+     * @param refreshToken
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<Void> refreshLogin(@CookieValue(value = "refreshToken") final String refreshToken) {
+        Jwt newJwt = authService.refreshLogin(refreshToken);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.AUTHORIZATION, newJwt.generateFullAccessTokenInfo())
+                .header(HttpHeaders.SET_COOKIE, createRefreshTokenCookie(newJwt.refreshToken()))
+                .build();
+    }
+
+    private String createRefreshTokenCookie(String refreshToken) {
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(Duration.ofDays(14))
+                .build();
+        return cookie.toString();
+    }
+}

--- a/member/src/main/java/ddalkak/member/domain/entity/RefreshToken.java
+++ b/member/src/main/java/ddalkak/member/domain/entity/RefreshToken.java
@@ -2,10 +2,13 @@ package ddalkak.member.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.Builder;
+import lombok.Getter;
 
 @Entity
-public class RefreshToken extends BaseEntity{
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+@Getter
+public class RefreshToken extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long tokenId;
     @OneToOne
     @JoinColumn(name = "member_id")
@@ -23,7 +26,7 @@ public class RefreshToken extends BaseEntity{
         this.token = token;
     }
 
-    public void setToken(String token) {
+    public void renewToken(String token) {
         this.token = token;
     }
 }

--- a/member/src/main/java/ddalkak/member/dto/jwt/Jwt.java
+++ b/member/src/main/java/ddalkak/member/dto/jwt/Jwt.java
@@ -6,4 +6,7 @@ import lombok.Builder;
 public record Jwt(String grantType,
                   String accessToken,
                   String refreshToken) {
+    public String generateFullAccessTokenInfo() {
+        return grantType + " " + accessToken;
+    }
 }

--- a/member/src/main/java/ddalkak/member/dto/jwt/RequiredClaims.java
+++ b/member/src/main/java/ddalkak/member/dto/jwt/RequiredClaims.java
@@ -1,10 +1,21 @@
 package ddalkak.member.dto.jwt;
 
 import ddalkak.member.domain.MemberType;
+import ddalkak.member.domain.entity.Member;
+import lombok.AccessLevel;
 import lombok.Builder;
 
 import java.util.List;
 
-@Builder
-public record RequiredClaims(Long memberId, String name, List<MemberType> roles) {
+@Builder(access = AccessLevel.PRIVATE)
+public record RequiredClaims(Long memberId,
+                             String name,
+                             List<MemberType> roles) {
+    public static RequiredClaims of(Member member) {
+        return RequiredClaims.builder()
+                .memberId(member.getMemberId())
+                .name(member.getName())
+                .roles(member.getRoles())
+                .build();
+    }
 }

--- a/member/src/main/java/ddalkak/member/repository/refreshtoken/DataJpaRefreshTokenRepository.java
+++ b/member/src/main/java/ddalkak/member/repository/refreshtoken/DataJpaRefreshTokenRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface DataJpaRefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByMember_MemberId(Long memberId);
+
+    Optional<RefreshToken> findByToken(String token);
 }

--- a/member/src/main/java/ddalkak/member/repository/refreshtoken/JpaRefreshTokenRepository.java
+++ b/member/src/main/java/ddalkak/member/repository/refreshtoken/JpaRefreshTokenRepository.java
@@ -20,4 +20,9 @@ public class JpaRefreshTokenRepository implements RefreshTokenRepository {
     public Optional<RefreshToken> findByMemberId(Long memberId) {
         return dataJpaRepository.findByMember_MemberId(memberId);
     }
+
+    @Override
+    public Optional<RefreshToken> findByToken(String token) {
+        return dataJpaRepository.findByToken(token);
+    }
 }

--- a/member/src/main/java/ddalkak/member/repository/refreshtoken/RefreshTokenRepository.java
+++ b/member/src/main/java/ddalkak/member/repository/refreshtoken/RefreshTokenRepository.java
@@ -8,4 +8,6 @@ public interface RefreshTokenRepository {
     RefreshToken save(RefreshToken token);
 
     Optional<RefreshToken> findByMemberId(Long memberId);
+
+    Optional<RefreshToken> findByToken(String token);
 }

--- a/member/src/main/java/ddalkak/member/service/auth/AuthService.java
+++ b/member/src/main/java/ddalkak/member/service/auth/AuthService.java
@@ -1,23 +1,40 @@
 package ddalkak.member.service.auth;
 
+import ddalkak.member.common.exception.RefreshTokenNotFoundException;
 import ddalkak.member.domain.CustomUserDetails;
 import ddalkak.member.domain.entity.Member;
+import ddalkak.member.domain.entity.RefreshToken;
+import ddalkak.member.dto.jwt.Jwt;
+import ddalkak.member.dto.jwt.RequiredClaims;
 import ddalkak.member.repository.member.MemberRepository;
+import ddalkak.member.repository.refreshtoken.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService implements UserDetailsService {
     private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
 
     @Override
     public UserDetails loadUserByUsername(String email) {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
         return new CustomUserDetails(member);
+    }
+
+    @Transactional
+    public Jwt refreshLogin(String refreshToken) {
+        RefreshToken loginMemberToken = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new RefreshTokenNotFoundException());
+        Jwt newJwt = jwtProvider.valueOf(RequiredClaims.of(loginMemberToken.getMember()));
+        loginMemberToken.renewToken(newJwt.refreshToken());
+        return newJwt;
     }
 }

--- a/member/src/main/java/ddalkak/member/service/auth/CustomAuthenticationSuccessHandler.java
+++ b/member/src/main/java/ddalkak/member/service/auth/CustomAuthenticationSuccessHandler.java
@@ -72,7 +72,7 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
     }
 
     private void setLoginSuccessResponse(HttpServletResponse response, Member loginMember, Jwt jwt) {
-        response.setHeader(HttpHeaders.AUTHORIZATION, jwt.grantType() + " " + jwt.accessToken());
+        response.setHeader(HttpHeaders.AUTHORIZATION, jwt.generateFullAccessTokenInfo());
         response.setHeader(HttpHeaders.SET_COOKIE, createRefreshTokenCookie(jwt));
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
@@ -84,10 +84,7 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
     }
 
     private Jwt generateJwt(Member loginMember) {
-        return jwtProvider.valueOf(new RequiredClaims(
-                loginMember.getMemberId(),
-                loginMember.getName(),
-                loginMember.getRoles()));
+        return jwtProvider.valueOf(RequiredClaims.of(loginMember));
     }
 
     private String createRefreshTokenCookie(Jwt jwt) {

--- a/member/src/main/java/ddalkak/member/service/refreshtoken/RefreshTokenService.java
+++ b/member/src/main/java/ddalkak/member/service/refreshtoken/RefreshTokenService.java
@@ -16,7 +16,7 @@ public class RefreshTokenService {
     public void saveOrUpdate(final Member member, final String refreshToken) {
         refreshTokenRepository.findByMemberId(member.getMemberId())
                 .ifPresentOrElse(
-                        existToken -> existToken.setToken(refreshToken),
+                        existToken -> existToken.renewToken(refreshToken),
                         () -> refreshTokenRepository.save(RefreshToken.builder()
                                 .member(member)
                                 .token(refreshToken)


### PR DESCRIPTION
- 앞 단의 인가 서버에서 클라이언트 측의 refresh token 검사는 마친 상황입니다. (위변조, 만료 기한 체크 등)
- member service에 요청이 들어오면 DB에 존재하는 토큰인지 검사 후, 새로운 Jwt를 발급해 반환해주면 됩니다.
- 재발급된 refreshToken은 DB에 업데이트 합니다.