### PR TITLE
상품 확률 조회를 위한 API 요청 기능 및 캐시 구현

### DIFF
--- a/draw/build.gradle
+++ b/draw/build.gradle
@@ -29,7 +29,16 @@ dependencies {
 	implementation("io.awspring.cloud:spring-cloud-aws-starter")
   	implementation("io.awspring.cloud:spring-cloud-aws-starter-parameter-store")
 
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	// Redis (Lettuce)
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+	// Web Client
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/draw/src/main/java/ddalkak/draw/common/config/RedisConfig.java
+++ b/draw/src/main/java/ddalkak/draw/common/config/RedisConfig.java
@@ -1,0 +1,41 @@
+package ddalkak.draw.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration defaultConf =
+            RedisCacheConfiguration.defaultCacheConfig()
+                    .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                                    .entryTtl(Duration.ofMinutes(10));
+
+        return RedisCacheManager.builder(cf)
+                .cacheDefaults(defaultConf)
+                .build();
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/common/config/WebClientConfig.java
+++ b/draw/src/main/java/ddalkak/draw/common/config/WebClientConfig.java
@@ -1,0 +1,13 @@
+package ddalkak.draw.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/domain/DrawProbability.java
+++ b/draw/src/main/java/ddalkak/draw/domain/DrawProbability.java
@@ -1,0 +1,9 @@
+package ddalkak.draw.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DrawProbability(@JsonProperty("probabilityRange") Long range,
+                              @JsonProperty("randomNumber") Long winNumber) {
+}

--- a/draw/src/main/java/ddalkak/draw/service/PrizeClient.java
+++ b/draw/src/main/java/ddalkak/draw/service/PrizeClient.java
@@ -1,0 +1,39 @@
+package ddalkak.draw.service;
+
+import ddalkak.draw.domain.DrawProbability;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PrizeClient {
+    @Value(value = "${uri.prize_server}")
+    private String targetAddress;
+    private final WebClient webClient;
+
+    @Cacheable(value = "probability", key = "#prizeId")
+    public DrawProbability fetch(final long prizeId) {
+        log.info("no cached, request origin server");
+        return webClient.get()
+                .uri(generateGETUri(prizeId))
+                .retrieve()
+                .bodyToMono(DrawProbability.class)
+                .block();
+    }
+
+    public String generateGETUri(final long prizeId) {
+        return UriComponentsBuilder
+                .fromUri(URI.create(targetAddress))
+                .path("/prize/{prizeId}")
+                .buildAndExpand(prizeId)
+                .toUriString();
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/service/PrizeClient.java
+++ b/draw/src/main/java/ddalkak/draw/service/PrizeClient.java
@@ -29,7 +29,7 @@ public class PrizeClient {
                 .block();
     }
 
-    public String generateGETUri(final long prizeId) {
+    private String generateGETUri(final long prizeId) {
         return UriComponentsBuilder
                 .fromUri(URI.create(targetAddress))
                 .path("/prize/{prizeId}")

--- a/draw/src/main/resources/application-local.yml
+++ b/draw/src/main/resources/application-local.yml
@@ -5,3 +5,10 @@ spring:
     activate:
       on-profile: local
     import: aws-parameterstore:/config/draw_local/
+  data:
+    redis:
+      port: 6379
+      host: localhost
+
+uri:
+  prize_server: http://localhost:8090

--- a/draw/src/test/java/ddalkak/draw/service/PrizeClientTest.java
+++ b/draw/src/test/java/ddalkak/draw/service/PrizeClientTest.java
@@ -1,0 +1,73 @@
+package ddalkak.draw.service;
+
+import ddalkak.draw.domain.DrawProbability;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
+class PrizeClientTest {
+    @Autowired
+    private PrizeClient prizeClient;
+    @MockitoBean(answers = Answers.RETURNS_DEEP_STUBS)
+    private WebClient webClient;
+    @Autowired
+    private CacheManager cacheManager;
+
+    @TestConfiguration
+    @EnableCaching
+    static class InMemoryCacheConfig {
+        @Bean
+        public CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager("probability");
+        }
+    }
+
+    @Test
+    void 캐시가_없는경우_API를_호출한다() {
+        //given
+        long prizeId = 1L;
+        DrawProbability response = new DrawProbability(1000L, 10L);
+        when(webClient.get()
+                .uri(anyString())
+                .retrieve()
+                .bodyToMono(DrawProbability.class)
+        ).thenReturn(Mono.just(response));
+        clearInvocations(webClient);
+        cacheManager.getCache("probability").clear();
+
+        //when
+        DrawProbability fetched = prizeClient.fetch(prizeId);
+
+        //when
+        verify(webClient, times(1)).get();
+    }
+
+    @Test
+    void 캐시가_있는경우_API를_호출하지_않는다() {
+        //given
+        long id = 1L;
+        DrawProbability cached = new DrawProbability(1000L, 10L);
+        cacheManager.getCache("probability").put(id, cached);
+
+        //when
+        DrawProbability fetched = prizeClient.fetch(id);
+
+        //then
+        verifyNoInteractions(webClient);
+        Assertions.assertThat(cached).isEqualTo(fetched);
+    }
+
+}


### PR DESCRIPTION
Case1. 레디스 캐시에 상품 정보 존재 시
요청 -> 캐시 확인 -> Cache Hit -> 반환

Case2. 레디스 캐시에 상품 정보 부재 시
요청 -> 캐시 확인 -> Cache Miss -> API 요청 및 캐시 저장 -> 반환

