### PR TITLE
응모 결과 확인 기능 개발

### DIFF
--- a/draw/src/main/java/ddalkak/draw/service/api/PrizeClient.java
+++ b/draw/src/main/java/ddalkak/draw/service/api/PrizeClient.java
@@ -1,4 +1,4 @@
-package ddalkak.draw.service;
+package ddalkak.draw.service.api;
 
 import ddalkak.draw.domain.DrawProbability;
 import lombok.RequiredArgsConstructor;

--- a/draw/src/main/java/ddalkak/draw/service/core/WinnerChecker.java
+++ b/draw/src/main/java/ddalkak/draw/service/core/WinnerChecker.java
@@ -1,0 +1,19 @@
+package ddalkak.draw.service.core;
+
+import ddalkak.draw.domain.DrawProbability;
+import ddalkak.draw.service.random.RandomGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WinnerChecker {
+    private final RandomGenerator randomGenerator;
+    
+    public boolean isWinnerDetermined(DrawProbability drawProbability) {
+        if (randomGenerator.rangeOf(drawProbability.range()) == drawProbability.winNumber()) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/service/random/RandomGenerator.java
+++ b/draw/src/main/java/ddalkak/draw/service/random/RandomGenerator.java
@@ -1,0 +1,5 @@
+package ddalkak.draw.service.random;
+
+public interface RandomGenerator {
+    long rangeOf(long range);
+}

--- a/draw/src/main/java/ddalkak/draw/service/random/SecureRandomGenerator.java
+++ b/draw/src/main/java/ddalkak/draw/service/random/SecureRandomGenerator.java
@@ -1,0 +1,14 @@
+package ddalkak.draw.service.random;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+@Component
+public class SecureRandomGenerator implements RandomGenerator {
+    private SecureRandom random = new SecureRandom();
+
+    public long rangeOf(long range) {
+        return random.nextLong(range) + 1;
+    }
+}

--- a/draw/src/test/java/ddalkak/draw/service/PrizeClientTest.java
+++ b/draw/src/test/java/ddalkak/draw/service/PrizeClientTest.java
@@ -1,6 +1,7 @@
 package ddalkak.draw.service;
 
 import ddalkak.draw.domain.DrawProbability;
+import ddalkak.draw.service.api.PrizeClient;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Answers;

--- a/draw/src/test/java/ddalkak/draw/service/core/WinnerCheckerTest.java
+++ b/draw/src/test/java/ddalkak/draw/service/core/WinnerCheckerTest.java
@@ -1,0 +1,46 @@
+package ddalkak.draw.service.core;
+
+import ddalkak.draw.domain.DrawProbability;
+import ddalkak.draw.service.random.SecureRandomGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WinnerCheckerTest {
+    @InjectMocks
+    private WinnerChecker winnerChecker;
+    @Mock
+    private SecureRandomGenerator randomGenerator;
+
+    @Test
+    void 당첨자가_결정되는_경우() {
+        //given
+        DrawProbability probability = new DrawProbability(1_000_000L, 100L);
+        when(randomGenerator.rangeOf(probability.range())).thenReturn(probability.winNumber());
+
+        //when
+        boolean result = winnerChecker.isWinnerDetermined(probability);
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 당첨자가_발생하지_않는_경우() {
+        //given
+        DrawProbability probability = new DrawProbability(1_000_000L, 100L);
+        when(randomGenerator.rangeOf(probability.range())).thenReturn(probability.winNumber() + 1);
+
+        //when
+        boolean result = winnerChecker.isWinnerDetermined(probability);
+
+        //then
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
- RandomGenerator를 인터페이스로 두었습니다. 구현체는 SecureRandomGenerator로 현재 SecureRandom을 활용해 난수를 생성합니다. (난수 생성 로직 변경을 고려했습니다.)
- Prize Service로부터 받아온 상품 당첨 확률 정보를 파라미터로 받아, WinnerChecker에서 내부적으로 RandomGenerator를 활용해 당첨 여부를 확인합니다.