### PR TITLE
유저 응모권 감소 기능 구현

### DIFF
--- a/draw/build.gradle
+++ b/draw/build.gradle
@@ -38,7 +38,11 @@ dependencies {
 	// Web Client
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	// 테스트용 임베디드 h2
+	testRuntimeOnly 'com.h2database:h2'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/draw/src/main/java/ddalkak/draw/common/exception/BusinessException.java
+++ b/draw/src/main/java/ddalkak/draw/common/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package ddalkak.draw.common.exception;
+
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(Throwable cause, ErrorCode errorCode) {
+        super(cause);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/common/exception/ErrorCode.java
+++ b/draw/src/main/java/ddalkak/draw/common/exception/ErrorCode.java
@@ -1,0 +1,12 @@
+package ddalkak.draw.common.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ErrorCode {
+    INSUFFICIENT_TICKET(HttpStatus.FORBIDDEN, "응모권이 부족합니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/draw/src/main/java/ddalkak/draw/common/exception/InsufficientTicketException.java
+++ b/draw/src/main/java/ddalkak/draw/common/exception/InsufficientTicketException.java
@@ -1,0 +1,7 @@
+package ddalkak.draw.common.exception;
+
+public class InsufficientTicketException extends BusinessException{
+    public InsufficientTicketException() {
+        super(ErrorCode.INSUFFICIENT_TICKET);
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/domain/entity/Ticket.java
+++ b/draw/src/main/java/ddalkak/draw/domain/entity/Ticket.java
@@ -1,0 +1,34 @@
+package ddalkak.draw.domain.entity;
+
+import ddalkak.draw.common.exception.InsufficientTicketException;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Ticket {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long memberId;
+    private int quantity;
+    @Version
+    private Long version; // 더블 클릭 등으로 인한 응모권 사용 동시성 제어
+
+    public void decrease() {
+        if (quantity <= 0) {
+            throw new InsufficientTicketException();
+        }
+        quantity--;
+    }
+
+    @Builder
+    public Ticket(Long memberId, int quantity) {
+        this.memberId = memberId;
+        this.quantity = quantity;
+    }
+
+    public Ticket() {
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/repository/ticket/JpaTicketRepository.java
+++ b/draw/src/main/java/ddalkak/draw/repository/ticket/JpaTicketRepository.java
@@ -1,0 +1,7 @@
+package ddalkak.draw.repository.ticket;
+
+import ddalkak.draw.domain.entity.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaTicketRepository extends JpaRepository<Ticket, Long>, TicketRepository {
+}

--- a/draw/src/main/java/ddalkak/draw/repository/ticket/TicketRepository.java
+++ b/draw/src/main/java/ddalkak/draw/repository/ticket/TicketRepository.java
@@ -1,0 +1,9 @@
+package ddalkak.draw.repository.ticket;
+
+import ddalkak.draw.domain.entity.Ticket;
+
+import java.util.Optional;
+
+public interface TicketRepository {
+    Optional<Ticket> findByMemberId(long memberId);
+}

--- a/draw/src/main/java/ddalkak/draw/service/ticket/TicketService.java
+++ b/draw/src/main/java/ddalkak/draw/service/ticket/TicketService.java
@@ -1,0 +1,20 @@
+package ddalkak.draw.service.ticket;
+
+import ddalkak.draw.domain.entity.Ticket;
+import ddalkak.draw.repository.ticket.TicketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TicketService {
+    private final TicketRepository ticketRepository;
+
+    @Transactional
+    public void useTicket(final long memberId) {
+        Ticket ticket = ticketRepository.findByMemberId(memberId)
+                .orElseThrow();
+        ticket.decrease();
+    }
+}

--- a/draw/src/main/resources/application-local.yml
+++ b/draw/src/main/resources/application-local.yml
@@ -9,6 +9,19 @@ spring:
     redis:
       port: 6379
       host: localhost
+  datasource:
+    url: ${db.url}
+    username: ${db.username}
+    password: ${db.password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    database: mysql
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
 
 uri:
   prize_server: http://localhost:8090

--- a/draw/src/test/java/ddalkak/draw/service/ticket/TicketServiceConcurrencyTest.java
+++ b/draw/src/test/java/ddalkak/draw/service/ticket/TicketServiceConcurrencyTest.java
@@ -1,0 +1,51 @@
+package ddalkak.draw.service.ticket;
+
+import ddalkak.draw.domain.entity.Ticket;
+import ddalkak.draw.repository.ticket.JpaTicketRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@SpringBootTest
+class TicketServiceConcurrencyTest {
+    @Autowired
+    private TicketService ticketService;
+    @Autowired
+    private JpaTicketRepository ticketRepository;
+
+    @Test
+    void 동시_응모권_차감_시_낙관적락_예외가_발생() throws InterruptedException {
+        //given
+        Ticket ticket = new Ticket(1L, 2);
+        ticketRepository.save(ticket);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        CountDownLatch latch = new CountDownLatch(2);
+        AtomicBoolean occurEx = new AtomicBoolean(false);
+
+        //when
+        for (int i = 0; i < 2; i++) {
+            executorService.execute(() -> {
+                try {
+                    ticketService.useTicket(1L);
+                } catch (OptimisticLockingFailureException e) {
+                    occurEx.set(true);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executorService.shutdown();
+
+        //then
+        Assertions.assertThat(occurEx.get()).isTrue();
+    }
+}

--- a/draw/src/test/java/ddalkak/draw/service/ticket/TicketServiceTest.java
+++ b/draw/src/test/java/ddalkak/draw/service/ticket/TicketServiceTest.java
@@ -1,0 +1,57 @@
+package ddalkak.draw.service.ticket;
+
+import ddalkak.draw.common.exception.InsufficientTicketException;
+import ddalkak.draw.domain.entity.Ticket;
+import ddalkak.draw.repository.ticket.TicketRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+class TicketServiceTest {
+    @InjectMocks
+    private TicketService ticketService;
+    @Mock
+    private TicketRepository ticketRepository;
+
+    @Test
+    void 정상_응모권_감소() {
+        //given
+        Ticket ticket = Ticket.builder()
+                .quantity(1)
+                .memberId(1L)
+                .build();
+        Mockito.when(ticketRepository.findByMemberId(1L))
+                .thenReturn(Optional.of(ticket));
+
+        //when
+        ticketService.useTicket(1L);
+
+        //then
+        assertThat(ticket.getQuantity()).isEqualTo(0);
+    }
+
+    @Test
+    void 예외발생_응모권_부족() {
+        //given
+        Ticket ticket = Ticket.builder()
+                .quantity(0)
+                .memberId(1L)
+                .build();
+        Mockito.when(ticketRepository.findByMemberId(1L))
+                .thenReturn(Optional.of(ticket));
+
+        //when & then
+        assertThatThrownBy(() -> ticketService.useTicket(1L))
+                .isInstanceOf(InsufficientTicketException.class);
+    }
+}

--- a/draw/src/test/resources/application-test.yml
+++ b/draw/src/test/resources/application-test.yml
@@ -1,0 +1,27 @@
+spring:
+  application:
+    name: draw
+  config:
+    activate:
+      on-profile: test
+    import: aws-parameterstore:/config/draw_local/
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL;INIT=SET REFERENTIAL_INTEGRITY FALSE
+    driver-class-name: org.h2.Driver
+    hikari:
+      username: sa
+      password:
+#      transaction-isolation: TRANSACTION_READ_UNCOMMITTED
+  data:
+    redis:
+      port: 6379
+      host: localhost
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect
+#logging:
+#  level:
+#    root: debug
+uri:
+  prize_server: http://localhost:8090

--- a/draw/src/test/resources/application.yml
+++ b/draw/src/test/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  application:
+    name: draw
+  profiles:
+    active: test


### PR DESCRIPTION
- 엔티티 메서드인 decrease()를 통해 응모권을 감소
- 보유 수량이 부족하면 InsufficientException 발생
- 더블 클릭, 악의적인 동시 요청을 방지하기 위한 JPA 버저닝(낙관적 락) 적용