### PR TITLE
로그인 이벤트 수신 후 데일리 출석 응모권 리워드 지급

### DIFF
--- a/draw/build.gradle
+++ b/draw/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 	// Web Client
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	// Kafka
+	implementation 'org.apache.kafka:kafka-streams'
+	implementation 'org.springframework.kafka:spring-kafka'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	// 테스트용 임베디드 h2

--- a/draw/src/main/java/ddalkak/draw/common/config/KafkaConfig.java
+++ b/draw/src/main/java/ddalkak/draw/common/config/KafkaConfig.java
@@ -1,0 +1,52 @@
+package ddalkak.draw.common.config;
+
+import ddalkak.draw.dto.event.LoginEvent;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * JsonDeserializer에 매핑할 Dto 타입 오류없이 사용하는 방법 <br>
+ * 1. Producer 및 Consumer 상호 간 설정으로 token:path를 약속 (token: 클래스명, 일치해야함) <br>
+ * 2. Consumer 측 JsonDeserializer 설정으로, Producer 에서 보낸 헤더 정보를 사용하지 않는 방법 (token 및 path가 달라도 형식만 맞으면 매핑)
+ * 현재 Producer 측은 ExternalEvent 라는 통일된 클래스로 발행, Consumer 측은 LoginEvent, SignInEvent 등 구분지어 소비하기 때문에 2번 방식 채택
+ */
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+    @Value(value = "${spring.kafka.consumer.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Bean
+    public ConsumerFactory<String, LoginEvent> loginConsumeFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(
+                configProps,
+                new StringDeserializer(),
+                new JsonDeserializer<>(LoginEvent.class, false)
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, LoginEvent> kafkaLoginListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, LoginEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(loginConsumeFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+        return factory;
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/domain/entity/Ticket.java
+++ b/draw/src/main/java/ddalkak/draw/domain/entity/Ticket.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Getter
 @Entity
 public class Ticket {
@@ -14,7 +16,8 @@ public class Ticket {
     private Long memberId;
     private int quantity;
     @Version
-    private Long version; // 더블 클릭 등으로 인한 응모권 사용 동시성 제어
+    private Long version;// 더블 클릭 등으로 인한 응모권 사용 동시성 제어
+    private LocalDate lastLogin;
 
     public void decrease() {
         if (quantity <= 0) {
@@ -23,10 +26,18 @@ public class Ticket {
         quantity--;
     }
 
+    public void rewardDailyLogin(LocalDate today) {
+        if (lastLogin == null || !lastLogin.isEqual(today)) {
+            quantity++;
+            lastLogin = today;
+        }
+    }
+
     @Builder
-    public Ticket(Long memberId, int quantity) {
-        this.memberId = memberId;
+    public Ticket(LocalDate lastLogin, int quantity, Long memberId) {
+        this.lastLogin = lastLogin;
         this.quantity = quantity;
+        this.memberId = memberId;
     }
 
     public Ticket() {

--- a/draw/src/main/java/ddalkak/draw/dto/event/LoginEvent.java
+++ b/draw/src/main/java/ddalkak/draw/dto/event/LoginEvent.java
@@ -1,0 +1,8 @@
+package ddalkak.draw.dto.event;
+
+import java.time.Instant;
+
+public record LoginEvent(Long eventId,
+                         Long memberId,
+                         Instant occurAt) {
+}

--- a/draw/src/main/java/ddalkak/draw/service/core/LoginEventListener.java
+++ b/draw/src/main/java/ddalkak/draw/service/core/LoginEventListener.java
@@ -1,0 +1,28 @@
+package ddalkak.draw.service.core;
+
+import ddalkak.draw.dto.event.LoginEvent;
+import ddalkak.draw.service.ticket.TicketService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LoginEventListener {
+    private final TicketService ticketService;
+
+    @KafkaListener(
+            groupId = "increase-ticket",
+            topics = "member.login",
+            containerFactory = "kafkaLoginListenerContainerFactory"
+    )
+    public void handleEvent(LoginEvent event, Acknowledgment ack) {
+        log.info("eventId={}, memberId={}, time={}", event.eventId(), event.memberId(), event.occurAt());
+        ticketService.rewardDailyLogin(event.memberId(), event.occurAt());
+        // 트랜잭션 예외 발생 시 offset 커밋하지 않음
+        ack.acknowledge();
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/service/ticket/TicketService.java
+++ b/draw/src/main/java/ddalkak/draw/service/ticket/TicketService.java
@@ -6,6 +6,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
 @Service
 @RequiredArgsConstructor
 public class TicketService {
@@ -16,5 +20,16 @@ public class TicketService {
         Ticket ticket = ticketRepository.findByMemberId(memberId)
                 .orElseThrow();
         ticket.decrease();
+    }
+
+    @Transactional
+    public void rewardDailyLogin(final long memberId, final Instant loginAt) {
+        Ticket ticket = ticketRepository.findByMemberId(memberId)
+                .orElseThrow();
+        ticket.rewardDailyLogin(toLocalDate(loginAt));
+    }
+
+    private LocalDate toLocalDate(Instant instant) {
+        return instant.atZone(ZoneId.of("Asia/Seoul")).toLocalDate();
     }
 }

--- a/draw/src/main/resources/application-local.yml
+++ b/draw/src/main/resources/application-local.yml
@@ -17,11 +17,14 @@ spring:
   jpa:
     database: mysql
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
         format_sql: true
+  kafka:
+    consumer:
+      bootstrap-servers: localhost:10000,localhost:10001,localhost:10002
 
 uri:
   prize_server: http://localhost:8090

--- a/draw/src/test/java/ddalkak/draw/service/ticket/TicketServiceConcurrencyTest.java
+++ b/draw/src/test/java/ddalkak/draw/service/ticket/TicketServiceConcurrencyTest.java
@@ -23,7 +23,10 @@ class TicketServiceConcurrencyTest {
     @Test
     void 동시_응모권_차감_시_낙관적락_예외가_발생() throws InterruptedException {
         //given
-        Ticket ticket = new Ticket(1L, 2);
+        Ticket ticket = Ticket.builder()
+                .memberId(1L)
+                .quantity(2)
+                .build();
         ticketRepository.save(ticket);
 
         ExecutorService executorService = Executors.newFixedThreadPool(2);


### PR DESCRIPTION
- 마지막 로그인을 알아야하기 때문에 Ticket 엔티티에 LocalDate 타입으로 lastLogin 필드를 추가했습니다.
- 또한 지급 조건을 확인하고 실제 응모권을 추가하는 로직은 엔티티 내부 메서드에 구현해 캡슐화 했습니다.
- Consumer의 offset 처리 방식은 Manual Commit 방식을 적용했습니다.
- 로그인 이벤트 리스너 내부에서는 로컬 트랜잭션이 완료된 뒤 offset을 커밋해 네트워크 오류 등으로 트랜잭션에 실패해도 메세지가 유실되지 않습니다.