### PR TITLE
회원가입 시 카프카로 이벤트 발행

### DIFF
--- a/member/src/main/java/ddalkak/member/domain/EventType.java
+++ b/member/src/main/java/ddalkak/member/domain/EventType.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum EventType {
-    LOGIN("member.login");
+    LOGIN("member.login"),
+    SIGNUP("member.signup");
 
     private final String topic;
 }

--- a/member/src/main/java/ddalkak/member/domain/entity/Outbox.java
+++ b/member/src/main/java/ddalkak/member/domain/entity/Outbox.java
@@ -21,12 +21,12 @@ public class Outbox extends BaseEntity{
     @Column(columnDefinition = "JSON")
     private String payload;
 
-    public static Outbox of(Long eventId, String payload) {
+    public static Outbox of(Long eventId, String payload, EventType eventType) {
         return Outbox.builder()
                 .eventId(eventId)
                 .payload(payload)
                 .status(EventStatus.READY_TO_PUBLISH)
-                .type(EventType.LOGIN)
+                .type(eventType)
                 .build();
     }
 

--- a/member/src/main/java/ddalkak/member/dto/event/ExternalEvent.java
+++ b/member/src/main/java/ddalkak/member/dto/event/ExternalEvent.java
@@ -16,4 +16,12 @@ public record ExternalEvent(Long eventId,
                 .occurAt(internalLoginEvent.occurAt())
                 .build();
     }
+
+    public static ExternalEvent of(InternalSignUpEvent internalEvent) {
+        return ExternalEvent.builder()
+                .eventId(internalEvent.eventId())
+                .memberId(internalEvent.memberId())
+                .occurAt(internalEvent.occurAt())
+                .build();
+    }
 }

--- a/member/src/main/java/ddalkak/member/dto/event/InternalSignUpEvent.java
+++ b/member/src/main/java/ddalkak/member/dto/event/InternalSignUpEvent.java
@@ -1,0 +1,19 @@
+package ddalkak.member.dto.event;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.Instant;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record InternalSignUpEvent(long eventId,
+                                  long memberId,
+                                  Instant occurAt) {
+    public static InternalSignUpEvent of(long eventId, long memberId) {
+        return InternalSignUpEvent.builder()
+                .eventId(eventId)
+                .memberId(memberId)
+                .occurAt(Instant.now())
+                .build();
+    }
+}

--- a/member/src/main/java/ddalkak/member/service/event/InternalSignUpEventHandler.java
+++ b/member/src/main/java/ddalkak/member/service/event/InternalSignUpEventHandler.java
@@ -2,9 +2,8 @@ package ddalkak.member.service.event;
 
 import ddalkak.member.domain.EventType;
 import ddalkak.member.dto.event.ExternalEvent;
-import ddalkak.member.dto.event.InternalLoginEvent;
+import ddalkak.member.dto.event.InternalSignUpEvent;
 import ddalkak.member.service.outbox.OutboxService;
-import ddalkak.member.service.refreshtoken.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -15,26 +14,20 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class InternalLoginEventHandler {
-    private final RefreshTokenService refreshTokenService;
+public class InternalSignUpEventHandler {
     private final OutboxService outboxService;
     private final ExternalEventPublisher externalEventPublisher;
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
-    public void saveRefreshToken(InternalLoginEvent event) {
-        refreshTokenService.saveOrUpdate(event.member(), event.refreshToken());
-    }
-
-    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
-    public void saveEventOnOutbox(InternalLoginEvent event) {
+    public void saveEventOnOutbox(InternalSignUpEvent event) {
         outboxService.saveEvent(
-                new ExternalEvent(event.eventId(), event.getMemberId(), event.occurAt()),
-                EventType.LOGIN);
+                new ExternalEvent(event.eventId(), event.memberId(), event.occurAt()),
+                EventType.SIGNUP);
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void publishExternalEvent(InternalLoginEvent internalEvent) {
-        externalEventPublisher.publish(EventType.LOGIN.getTopic(), ExternalEvent.of(internalEvent));
+    public void publishExternalEvent(InternalSignUpEvent internalEvent) {
+        externalEventPublisher.publish(EventType.SIGNUP.getTopic(), ExternalEvent.of(internalEvent));
     }
 }

--- a/member/src/main/java/ddalkak/member/service/member/MemberService.java
+++ b/member/src/main/java/ddalkak/member/service/member/MemberService.java
@@ -1,11 +1,14 @@
 package ddalkak.member.service.member;
 
 import ddalkak.member.domain.entity.Member;
+import ddalkak.member.dto.event.InternalSignUpEvent;
 import ddalkak.member.dto.request.SignUpRequest;
 import ddalkak.member.common.exception.DuplicatedEmailException;
 import ddalkak.member.common.exception.errorcode.ErrorCode;
 import ddalkak.member.repository.member.MemberRepository;
+import ddalkak.member.service.event.UniqueIdGenerator;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,15 +18,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final UniqueIdGenerator idGenerator;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
+    /**
+     *
+     * @return savedMember
+     * 회원가입 외 부가적인 로직은 애플리케이션 이벤트를 발행해 별도로 처리
+     */
     @Transactional
     public Member signup(final SignUpRequest request) {
         validateDuplicatedEmail(request.email());
-        return memberRepository.save(Member.createGeneralMember(
+        Member savedMember = memberRepository.save(Member.createGeneralMember(
                 request.name(),
                 request.email(),
                 passwordEncoder.encode(request.password())
         ));
+        applicationEventPublisher.publishEvent(InternalSignUpEvent.of(idGenerator.generate(), savedMember.getMemberId()));
+        return savedMember;
     }
 
     @Transactional(readOnly = true)

--- a/member/src/main/java/ddalkak/member/service/outbox/OutboxService.java
+++ b/member/src/main/java/ddalkak/member/service/outbox/OutboxService.java
@@ -2,6 +2,7 @@ package ddalkak.member.service.outbox;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import ddalkak.member.domain.EventType;
 import ddalkak.member.domain.entity.Outbox;
 import ddalkak.member.dto.event.ExternalEvent;
 import ddalkak.member.dto.event.PendingEvent;
@@ -22,14 +23,14 @@ public class OutboxService {
     private final ObjectMapper objectMapper;
 
     @Transactional
-    public void saveLoginEvent(ExternalEvent loginEvent) {
+    public void saveEvent(ExternalEvent loginEvent, EventType eventType) {
         String payload = null;
         try {
             payload = objectMapper.writeValueAsString(loginEvent);
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("payload 직렬화 실패");
         }
-        outboxRepository.save(Outbox.of(loginEvent.eventId(), payload));
+        outboxRepository.save(Outbox.of(loginEvent.eventId(), payload, eventType));
     }
 
     @Transactional


### PR DESCRIPTION
- 기존 MemberService의 회원가입 로직에서 내부(애플리케이션) 이벤트를 발행하는 부분이 추가됨
- 해당 내부 이벤트는 InternalSignUpEventHandler에서 처리, Outbox 테이블에 이벤트 저장 및 이벤트 발행