### PR TITLE
[draw] 회원가입 이벤트 수신 후 유저 티켓 생성(초기화)

### DIFF
--- a/draw/src/main/java/ddalkak/draw/common/config/KafkaConfig.java
+++ b/draw/src/main/java/ddalkak/draw/common/config/KafkaConfig.java
@@ -1,6 +1,7 @@
 package ddalkak.draw.common.config;
 
 import ddalkak.draw.dto.event.LoginEvent;
+import ddalkak.draw.dto.event.SignUpEvent;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,15 +29,11 @@ public class KafkaConfig {
     @Value(value = "${spring.kafka.consumer.bootstrap-servers}")
     private String bootstrapAddress;
 
+    // 로그인 이벤트 처리용 컨슈머 팩토리 설정
     @Bean
     public ConsumerFactory<String, LoginEvent> loginConsumeFactory() {
-        Map<String, Object> configProps = new HashMap<>();
-        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
-        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-
         return new DefaultKafkaConsumerFactory<>(
-                configProps,
+                generateDefaultConsumerConfig(),
                 new StringDeserializer(),
                 new JsonDeserializer<>(LoginEvent.class, false)
         );
@@ -48,5 +45,31 @@ public class KafkaConfig {
         factory.setConsumerFactory(loginConsumeFactory());
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
         return factory;
+    }
+
+    // 회원가입 이벤트 처리용 컨슈머 팩토리 설정
+    @Bean
+    public ConsumerFactory<String, SignUpEvent> signupConsumeFactory() {
+        return new DefaultKafkaConsumerFactory<>(
+                generateDefaultConsumerConfig(),
+                new StringDeserializer(),
+                new JsonDeserializer<>(SignUpEvent.class, false)
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, SignUpEvent> kafkaSignUpListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, SignUpEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(signupConsumeFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+        return factory;
+    }
+
+    private Map<String, Object> generateDefaultConsumerConfig() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        return configProps;
     }
 }

--- a/draw/src/main/java/ddalkak/draw/domain/entity/Ticket.java
+++ b/draw/src/main/java/ddalkak/draw/domain/entity/Ticket.java
@@ -13,11 +13,21 @@ public class Ticket {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column(unique = true)
     private Long memberId;
     private int quantity;
+    // 더블 클릭 등으로 인한 응모권 사용 동시성 제어
+    // 로그인 중복 메세지 발행으로 인한 동시성 이슈를 제어
     @Version
-    private Long version;// 더블 클릭 등으로 인한 응모권 사용 동시성 제어
+    private Long version;
     private LocalDate lastLogin;
+
+    public static Ticket of(long memberId) {
+        return Ticket.builder()
+                .memberId(memberId)
+                .quantity(0)
+                .build();
+    }
 
     public void decrease() {
         if (quantity <= 0) {

--- a/draw/src/main/java/ddalkak/draw/dto/event/SignUpEvent.java
+++ b/draw/src/main/java/ddalkak/draw/dto/event/SignUpEvent.java
@@ -1,0 +1,8 @@
+package ddalkak.draw.dto.event;
+
+import java.time.Instant;
+
+public record SignUpEvent(long eventId,
+                          long memberId,
+                          Instant occurAt) {
+}

--- a/draw/src/main/java/ddalkak/draw/repository/ticket/TicketRepository.java
+++ b/draw/src/main/java/ddalkak/draw/repository/ticket/TicketRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface TicketRepository {
     Optional<Ticket> findByMemberId(long memberId);
+
+    Ticket save(Ticket ticket);
 }

--- a/draw/src/main/java/ddalkak/draw/service/core/SignUpEventListener.java
+++ b/draw/src/main/java/ddalkak/draw/service/core/SignUpEventListener.java
@@ -1,0 +1,27 @@
+package ddalkak.draw.service.core;
+
+import ddalkak.draw.dto.event.SignUpEvent;
+import ddalkak.draw.service.ticket.TicketService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SignUpEventListener {
+    private final TicketService ticketService;
+
+    @KafkaListener(
+            groupId = "init-ticket",
+            topics = "member.signup",
+            containerFactory = "kafkaSignUpListenerContainerFactory"
+    )
+    public void handleEvent(SignUpEvent event, Acknowledgment ack) {
+        log.info("eventId={}, memberId={}, time={}", event.eventId(), event.memberId(), event.occurAt());
+        ticketService.initTicket(event.memberId());
+        ack.acknowledge();
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/service/ticket/TicketService.java
+++ b/draw/src/main/java/ddalkak/draw/service/ticket/TicketService.java
@@ -16,6 +16,11 @@ public class TicketService {
     private final TicketRepository ticketRepository;
 
     @Transactional
+    public void initTicket(final long newMemberId) {
+        ticketRepository.save(Ticket.of(newMemberId));
+    }
+
+    @Transactional
     public void useTicket(final long memberId) {
         Ticket ticket = ticketRepository.findByMemberId(memberId)
                 .orElseThrow();

--- a/draw/src/main/resources/application-local.yml
+++ b/draw/src/main/resources/application-local.yml
@@ -17,7 +17,7 @@ spring:
   jpa:
     database: mysql
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:

--- a/draw/src/test/java/ddalkak/draw/service/ticket/TicketServiceConcurrencyTest.java
+++ b/draw/src/test/java/ddalkak/draw/service/ticket/TicketServiceConcurrencyTest.java
@@ -2,6 +2,7 @@ package ddalkak.draw.service.ticket;
 
 import ddalkak.draw.domain.entity.Ticket;
 import ddalkak.draw.repository.ticket.JpaTicketRepository;
+import ddalkak.draw.repository.ticket.TicketRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +19,7 @@ class TicketServiceConcurrencyTest {
     @Autowired
     private TicketService ticketService;
     @Autowired
-    private JpaTicketRepository ticketRepository;
+    private TicketRepository ticketRepository;
 
     @Test
     void 동시_응모권_차감_시_낙관적락_예외가_발생() throws InterruptedException {

--- a/draw/src/test/resources/application-test.yml
+++ b/draw/src/test/resources/application-test.yml
@@ -20,6 +20,9 @@ spring:
     hibernate:
       ddl-auto: create-drop
     database-platform: org.hibernate.dialect.H2Dialect
+  kafka:
+    consumer:
+      bootstrap-servers: localhost:10000,localhost:10001,localhost:10002
 #logging:
 #  level:
 #    root: debug


### PR DESCRIPTION
회원가입 이벤트 수신 후 최초 수량 0개로 초기화합니다.

다만, Member 서비스 측에서 우연치 않게 중복 메세지가 발행되는 경우가 존재합니다.
1. 비지니스 로직 처리 후 최초 1회 발행 시도
2. 스케줄러에 의한 READY_TO_PUBLISH 이벤트 발행

스케줄러가 짧은 주기로 활발히 돌아가는 경우에 위 두 상황이 동시에 발생해 중복 메세지가 발행됩니다.
(1번을 진행하면 완전히 Producing에 성공한 뒤, 콜백을 통해 상태를 PUBLISHED로 변경하기 때문에, 그 사이에 스케줄러가 돌아갈 수 있음)

우선 Draw 서비스 측에서는 아래와 같이 중복 메세지를 Consume해도 멱등성 있게 처리됩니다.
1. 회원가입 이벤트 중복 수신: Ticket을 생성할 때 memberId 필드에 유니크 제약 조건을 걸어, 후에 처리된 이벤트는 예외를 반환합니다.
2. 로그인 이벤트 중복 수신: 동시에 두 이벤트가 처리된다면 리워드 보상이 1이 아닌 2가 증가할 수 있는데, 버저닝을 통한 동시성 제어로 멱등성 있게 처리됩니다.

다만 아래에 대해서는 논의가 필요할것 같습니다.
1. Member 측에서 중복 메세지를 발행하도록 두는 것이 최선일지
2. Draw 측에서 현재는 eventId를 통해 중복 체크를 하지 않고 내부 비지니스적으로 멱등성을 보장하고 있음. eventId를 통한 필터링을 구현해야 할지

이 부분은 Issue에 남겨놓겠습니다. 다음 회의때 이야기해봅시다.