### PR TITLE
[응모] 경품 재고 감소 이벤트 수신 후 응모 결과 확정 처리

### DIFF
--- a/draw/src/main/java/ddalkak/draw/common/config/KafkaConsumerConfig.java
+++ b/draw/src/main/java/ddalkak/draw/common/config/KafkaConsumerConfig.java
@@ -1,5 +1,6 @@
 package ddalkak.draw.common.config;
 
+import ddalkak.draw.dto.event.DecreaseStockEvent;
 import ddalkak.draw.dto.event.LoginEvent;
 import ddalkak.draw.dto.event.SignUpEvent;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -71,5 +72,23 @@ public class KafkaConsumerConfig {
         configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
         return configProps;
+    }
+
+    // 경품 재고 감소 이벤트 처리용 컨슈머 팩토리 설정
+    @Bean
+    public ConsumerFactory<String, DecreaseStockEvent> decreaseResultConsumeFactory() {
+        return new DefaultKafkaConsumerFactory<>(
+                generateDefaultConsumerConfig(),
+                new StringDeserializer(),
+                new JsonDeserializer<>(DecreaseStockEvent.class, false)
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, DecreaseStockEvent> kafkaDecreaseResultListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, DecreaseStockEvent> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(decreaseResultConsumeFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+        return factory;
     }
 }

--- a/draw/src/main/java/ddalkak/draw/domain/entity/Draw.java
+++ b/draw/src/main/java/ddalkak/draw/domain/entity/Draw.java
@@ -4,8 +4,10 @@ import ddalkak.draw.domain.DrawResult;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Draw extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -50,5 +52,9 @@ public class Draw extends BaseEntity {
             return true;
         }
         return false;
+    }
+
+    public void setResult(DrawResult result) {
+        this.result = result;
     }
 }

--- a/draw/src/main/java/ddalkak/draw/dto/event/DecreaseResult.java
+++ b/draw/src/main/java/ddalkak/draw/dto/event/DecreaseResult.java
@@ -1,0 +1,6 @@
+package ddalkak.draw.dto.event;
+
+public enum DecreaseResult {
+    SUCCESS,
+    FAILURE
+}

--- a/draw/src/main/java/ddalkak/draw/dto/event/DecreaseStockEvent.java
+++ b/draw/src/main/java/ddalkak/draw/dto/event/DecreaseStockEvent.java
@@ -1,0 +1,7 @@
+package ddalkak.draw.dto.event;
+
+public record DecreaseStockEvent(long eventId,
+                                 long drawId,
+                                 long prizeId,
+                                 DecreaseResult result) {
+}

--- a/draw/src/main/java/ddalkak/draw/dto/event/DrawWinEvent.java
+++ b/draw/src/main/java/ddalkak/draw/dto/event/DrawWinEvent.java
@@ -7,11 +7,13 @@ import java.time.Instant;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record DrawWinEvent(long eventId,
+                           long drawId,
                            long prizeId,
                            Instant occurAt) implements ExternalEvent {
-    public static DrawWinEvent of(long eventId, long prizeId) {
+    public static DrawWinEvent of(long eventId, long drawId, long prizeId) {
         return DrawWinEvent.builder()
                 .eventId(eventId)
+                .drawId(drawId)
                 .prizeId(prizeId)
                 .occurAt(Instant.now())
                 .build();

--- a/draw/src/main/java/ddalkak/draw/repository/draw/DrawRepository.java
+++ b/draw/src/main/java/ddalkak/draw/repository/draw/DrawRepository.java
@@ -2,6 +2,10 @@ package ddalkak.draw.repository.draw;
 
 import ddalkak.draw.domain.entity.Draw;
 
+import java.util.Optional;
+
 public interface DrawRepository {
     Draw save(Draw draw);
+
+    Optional<Draw> findById(Long id);
 }

--- a/draw/src/main/java/ddalkak/draw/service/core/DrawService.java
+++ b/draw/src/main/java/ddalkak/draw/service/core/DrawService.java
@@ -1,5 +1,6 @@
 package ddalkak.draw.service.core;
 
+import ddalkak.draw.domain.DrawResult;
 import ddalkak.draw.domain.entity.Draw;
 import ddalkak.draw.dto.event.DrawWinEvent;
 import ddalkak.draw.repository.draw.DrawRepository;
@@ -24,7 +25,14 @@ public class DrawService {
         drawRepository.save(draw);
 
         if (draw.isWinPending()) {
-            applicationEventPublisher.publishEvent(DrawWinEvent.of(idGenerator.generate(), prizeId));
+            applicationEventPublisher.publishEvent(DrawWinEvent.of(idGenerator.generate(), draw.getId(), prizeId));
         }
+    }
+
+    @Transactional
+    public void finalizeDrawResult(final long drawId, final DrawResult result) {
+        Draw draw = drawRepository.findById(drawId)
+                .orElseThrow();
+        draw.setResult(result);
     }
 }

--- a/draw/src/main/java/ddalkak/draw/service/event/DecreaseStockEventListener.java
+++ b/draw/src/main/java/ddalkak/draw/service/event/DecreaseStockEventListener.java
@@ -1,0 +1,33 @@
+package ddalkak.draw.service.event;
+
+import ddalkak.draw.domain.DrawResult;
+import ddalkak.draw.dto.event.DecreaseResult;
+import ddalkak.draw.dto.event.DecreaseStockEvent;
+import ddalkak.draw.service.core.DrawService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DecreaseStockEventListener {
+    private final DrawService drawService;
+
+    @KafkaListener(
+            groupId = "determine-draw-result",
+            topics = "prize.decrease-stock",
+            containerFactory = "kafkaDecreaseResultListenerContainerFactory"
+    )
+    public void handleEvent(DecreaseStockEvent event, Acknowledgment ack) {
+        log.info("eventId={}, prizeId={}, result={}", event.eventId(), event.prizeId(), event.result());
+        if (event.result() == DecreaseResult.SUCCESS) {
+            drawService.finalizeDrawResult(event.drawId(), DrawResult.WIN);
+        } else {
+            drawService.finalizeDrawResult(event.drawId(), DrawResult.LOSE);
+        }
+        ack.acknowledge();
+    }
+}


### PR DESCRIPTION
- SUCCESS 응답이면 WIN으로 확정, FAILURE 응답이면 재고 부족 -> LOSE로 확정
- [Draw.java] DrawResult setter 추가
- [DrawRepository.java] findById() 메서드 추가
- [DrawWinEvent.java, DecreaseStockEvent.java] drawId 필드 추가