### PR TITLE
[응모] 응모권 체크 및 차감 로직 추가

### DIFF
--- a/draw/src/main/java/ddalkak/draw/common/exception/BusinessException.java
+++ b/draw/src/main/java/ddalkak/draw/common/exception/BusinessException.java
@@ -1,5 +1,8 @@
 package ddalkak.draw.common.exception;
 
+import lombok.Getter;
+
+@Getter
 public class BusinessException extends RuntimeException {
     private final ErrorCode errorCode;
 

--- a/draw/src/main/java/ddalkak/draw/common/exception/ErrorCode.java
+++ b/draw/src/main/java/ddalkak/draw/common/exception/ErrorCode.java
@@ -1,11 +1,14 @@
 package ddalkak.draw.common.exception;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+@Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    INSUFFICIENT_TICKET(HttpStatus.FORBIDDEN, "응모권이 부족합니다.");
+    INSUFFICIENT_TICKET(HttpStatus.FORBIDDEN, "응모권이 부족합니다."),
+    UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예상치 못한 에러가 발생했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/draw/src/main/java/ddalkak/draw/common/exception/GlobalExceptionHandler.java
+++ b/draw/src/main/java/ddalkak/draw/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,45 @@
+package ddalkak.draw.common.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        return makeErrorResponse(e.getErrorCode());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexceptedException(Exception e) {
+        log.error("occur unexcepted exception, e={}", e);
+        return makeErrorResponse(ErrorCode.UNEXPECTED_ERROR);
+    }
+
+    private ResponseEntity<ErrorResponse> makeErrorResponse(ErrorCode errorCode) {
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.builder()
+                        .errorCode(errorCode.name())
+                        .message(errorCode.getMessage())
+                        .build());
+    }
+
+    @Getter
+    static class ErrorResponse {
+        private final String errorCode;
+        private final String message;
+
+        @Builder
+        public ErrorResponse(String errorCode, String message) {
+            this.errorCode = errorCode;
+            this.message = message;
+        }
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/service/core/DrawService.java
+++ b/draw/src/main/java/ddalkak/draw/service/core/DrawService.java
@@ -5,6 +5,7 @@ import ddalkak.draw.domain.entity.Draw;
 import ddalkak.draw.dto.event.DrawWinEvent;
 import ddalkak.draw.repository.draw.DrawRepository;
 import ddalkak.draw.service.event.UniqueIdGenerator;
+import ddalkak.draw.service.ticket.TicketService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class DrawService {
+    private final TicketService ticketService;
     private final DrawMachine drawMachine;
     private final DrawRepository drawRepository;
     private final UniqueIdGenerator idGenerator;
@@ -20,6 +22,8 @@ public class DrawService {
 
     @Transactional
     public void luckyDraw(final long memberId, final long prizeId) {
+        // 유저 응모권을 한장 소모한다.
+        ticketService.useTicket(memberId);
         // 경품 응모 머신으로부터 결과를 받아온 뒤 저장한다.
         Draw draw = drawMachine.attempt(memberId, prizeId);
         drawRepository.save(draw);


### PR DESCRIPTION
- 기존 응모 프로세스 첫 부분에 응모권 개수 체크 및 차감하는 로직 추가
- 구현은 이미 완료, 서비스단 호출하는 부분만 추가