### PR TITLE
[회원] access token 응답 위치 변경

### DIFF
--- a/member/src/main/java/ddalkak/member/common/exception/GlobalExceptionHandler.java
+++ b/member/src/main/java/ddalkak/member/common/exception/GlobalExceptionHandler.java
@@ -4,17 +4,27 @@ import ddalkak.member.common.exception.errorcode.ErrorCode;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
 @RestControllerAdvice
-public class GlobalExceptionHandler extends ResponseEntityExceptionHandler { // Spring MVC Exception은 ResponseEntityExceptionHandler에 의해 기본 처리
+public class GlobalExceptionHandler {
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
         return makeErrorResponse(e.getErrorCode());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        FieldError fieldError = e.getBindingResult().getFieldError();
+        String errorMessage = fieldError.getField() + ": " + fieldError.getDefaultMessage();
+        return makeErrorResponse(HttpStatus.BAD_REQUEST, "BAD_REQUEST", errorMessage);
     }
 
     @ExceptionHandler(Exception.class)
@@ -29,6 +39,15 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler { // 
                 .body(ErrorResponse.builder()
                         .errorCode(errorCode.name())
                         .message(errorCode.getMessage())
+                        .build());
+    }
+
+    private ResponseEntity<ErrorResponse> makeErrorResponse(HttpStatus status, String errorCode, String errorMessage) {
+        return ResponseEntity
+                .status(status)
+                .body(ErrorResponse.builder()
+                        .errorCode(errorCode)
+                        .message(errorMessage)
                         .build());
     }
 

--- a/member/src/main/java/ddalkak/member/controller/AuthController.java
+++ b/member/src/main/java/ddalkak/member/controller/AuthController.java
@@ -1,8 +1,10 @@
 package ddalkak.member.controller;
 
+import ddalkak.member.domain.JwtConstants;
 import ddalkak.member.dto.jwt.Jwt;
 import ddalkak.member.service.auth.AuthService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.server.Cookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -28,17 +30,18 @@ public class AuthController {
     public ResponseEntity<Void> refreshLogin(@CookieValue(value = "refreshToken") final String refreshToken) {
         Jwt newJwt = authService.refreshLogin(refreshToken);
         return ResponseEntity.ok()
-                .header(HttpHeaders.AUTHORIZATION, newJwt.generateFullAccessTokenInfo())
-                .header(HttpHeaders.SET_COOKIE, createRefreshTokenCookie(newJwt.refreshToken()))
+                .header(HttpHeaders.SET_COOKIE, createCookie(newJwt.accessToken(), JwtConstants.ACCESS_TOKEN))
+                .header(HttpHeaders.SET_COOKIE, createCookie(newJwt.refreshToken(), JwtConstants.REFRESH_TOKEN))
                 .build();
     }
 
-    private String createRefreshTokenCookie(String refreshToken) {
-        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+    private String createCookie(String token, JwtConstants constant) {
+        ResponseCookie cookie = ResponseCookie.from(constant.getKey(), token)
                 .httpOnly(true)
                 .secure(true)
+                .sameSite(Cookie.SameSite.LAX.name())
                 .path("/")
-                .maxAge(Duration.ofDays(14))
+                .maxAge(constant.getDuration())
                 .build();
         return cookie.toString();
     }

--- a/member/src/main/java/ddalkak/member/domain/JwtConstants.java
+++ b/member/src/main/java/ddalkak/member/domain/JwtConstants.java
@@ -1,0 +1,16 @@
+package ddalkak.member.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Getter
+public enum JwtConstants {
+    ACCESS_TOKEN("accessToken", Duration.ofHours(1)),
+    REFRESH_TOKEN("refreshToken", Duration.ofDays(14));
+
+    private final String key;
+    private final Duration duration;
+}

--- a/member/src/main/java/ddalkak/member/service/auth/CustomAuthenticationSuccessHandler.java
+++ b/member/src/main/java/ddalkak/member/service/auth/CustomAuthenticationSuccessHandler.java
@@ -2,6 +2,7 @@ package ddalkak.member.service.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import ddalkak.member.domain.CustomUserDetails;
+import ddalkak.member.domain.JwtConstants;
 import ddalkak.member.domain.entity.Member;
 import ddalkak.member.dto.event.InternalLoginEvent;
 import ddalkak.member.dto.jwt.Jwt;
@@ -12,6 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.server.Cookie;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -24,7 +26,6 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.io.IOException;
-import java.time.Duration;
 
 @RequiredArgsConstructor
 @Component
@@ -72,8 +73,8 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
     }
 
     private void setLoginSuccessResponse(HttpServletResponse response, Member loginMember, Jwt jwt) {
-        response.setHeader(HttpHeaders.AUTHORIZATION, jwt.generateFullAccessTokenInfo());
-        response.setHeader(HttpHeaders.SET_COOKIE, createRefreshTokenCookie(jwt));
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(jwt.accessToken(), JwtConstants.ACCESS_TOKEN));
+        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(jwt.refreshToken(), JwtConstants.REFRESH_TOKEN));
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
         try {
@@ -87,12 +88,13 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
         return jwtProvider.valueOf(RequiredClaims.of(loginMember));
     }
 
-    private String createRefreshTokenCookie(Jwt jwt) {
-        ResponseCookie cookie = ResponseCookie.from("refreshToken", jwt.refreshToken())
+    private String createCookie(String token, JwtConstants constant) {
+        ResponseCookie cookie = ResponseCookie.from(constant.getKey(), token)
                 .httpOnly(true)
                 .secure(true)
+                .sameSite(Cookie.SameSite.LAX.name())
                 .path("/")
-                .maxAge(Duration.ofDays(14))
+                .maxAge(constant.getDuration())
                 .build();
         return cookie.toString();
     }


### PR DESCRIPTION
- 기존 Authorization 헤더에서 쿠키로 변경
- 논의한 방향대로 쿠키에 httpOnly, secure, samesite 설정 + 짧은 만료기한 설정으로 XSS 및 CSRF 공격에 대해 우선 처리하도록 변경했습니다.
- Input Validation 실패(Bad Request) 예외를 다루는 기능을 추가했습니다.