### PR TITLE
[인증/인가] Owner 검증기 구현

### DIFF
--- a/auth/src/main/java/ddalkak/auth/aop/aspect/GlobalExceptionHandler.java
+++ b/auth/src/main/java/ddalkak/auth/aop/aspect/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package ddalkak.auth.aop.aspect;
 
+import ddalkak.auth.common.exception.OwnerMismatchException;
 import ddalkak.auth.common.exception.RoleMismatchException;
 import ddalkak.auth.dto.ApiGatewayLambdaResponse;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -34,6 +35,9 @@ public class GlobalExceptionHandler {
         } catch (RoleMismatchException e) {
             log.info("Unauthorized User Role", e);
             return ApiGatewayLambdaResponse.errorOf("MISMATCH_ROLE");
+        } catch (OwnerMismatchException e) {
+            log.info("Is Not Owner", e);
+            return ApiGatewayLambdaResponse.errorOf("MISMATCH_OWNER");
         }
     }
 }

--- a/auth/src/main/java/ddalkak/auth/common/exception/OwnerMismatchException.java
+++ b/auth/src/main/java/ddalkak/auth/common/exception/OwnerMismatchException.java
@@ -1,0 +1,7 @@
+package ddalkak.auth.common.exception;
+
+public class OwnerMismatchException extends RuntimeException {
+    public OwnerMismatchException(String message) {
+        super(message);
+    }
+}

--- a/auth/src/main/java/ddalkak/auth/config/SupportedValidatorConfig.java
+++ b/auth/src/main/java/ddalkak/auth/config/SupportedValidatorConfig.java
@@ -1,6 +1,7 @@
 package ddalkak.auth.config;
 
 import ddalkak.auth.validator.AdminValidator;
+import ddalkak.auth.validator.OwnerCheckValidator;
 import ddalkak.auth.validator.Validator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -13,11 +14,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SupportedValidatorConfig {
     private final AdminValidator adminValidator;
+    private final OwnerCheckValidator ownerCheckValidator;
 
     @Bean
     public List<Validator> validators() {
         List<Validator> validators = new ArrayList<>();
         validators.add(adminValidator);
+        validators.add(ownerCheckValidator);
         return validators;
     }
 }

--- a/auth/src/main/java/ddalkak/auth/enums/MicroServicesConstants.java
+++ b/auth/src/main/java/ddalkak/auth/enums/MicroServicesConstants.java
@@ -1,0 +1,15 @@
+package ddalkak.auth.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum MicroServicesConstants {
+    MEMBER_SERVICE("/member"),
+    DRAW_SERVICE("/draw"),
+    TICKET_SERVICE("/ticket"),
+    PRIZE_SERVICE("/prize");
+
+    private final String prefix;
+}

--- a/auth/src/main/java/ddalkak/auth/validator/AdminValidator.java
+++ b/auth/src/main/java/ddalkak/auth/validator/AdminValidator.java
@@ -2,11 +2,13 @@ package ddalkak.auth.validator;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
 import ddalkak.auth.common.service.JwtService;
+import ddalkak.auth.dto.ApiGatewayLambdaResponse;
 import ddalkak.auth.dto.HttpRequestSignature;
 import ddalkak.auth.dto.UserContext;
-import ddalkak.auth.dto.ApiGatewayLambdaResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import static ddalkak.auth.enums.MicroServicesConstants.PRIZE_SERVICE;
 
 @Component
 @RequiredArgsConstructor
@@ -21,7 +23,7 @@ public class AdminValidator implements Validator {
          */
         String path = httpRequestSignature.path();
         String httpMethod = httpRequestSignature.httpMethod();
-        return path.startsWith("/prize") && (httpMethod.equals("POST") || httpMethod.equals("PATCH"));
+        return path.startsWith(PRIZE_SERVICE.getPrefix()) && (httpMethod.equals("POST") || httpMethod.equals("PATCH"));
     }
 
     @Override

--- a/auth/src/main/java/ddalkak/auth/validator/OwnerCheckValidator.java
+++ b/auth/src/main/java/ddalkak/auth/validator/OwnerCheckValidator.java
@@ -1,0 +1,63 @@
+package ddalkak.auth.validator;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+import ddalkak.auth.common.exception.OwnerMismatchException;
+import ddalkak.auth.dto.ApiGatewayLambdaResponse;
+import ddalkak.auth.dto.HttpRequestSignature;
+import ddalkak.auth.dto.UserContext;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+import static ddalkak.auth.enums.MicroServicesConstants.MEMBER_SERVICE;
+import static ddalkak.auth.enums.MicroServicesConstants.TICKET_SERVICE;
+
+@Component
+public class OwnerCheckValidator implements Validator {
+
+    @Override
+    public boolean supports(HttpRequestSignature httpRequestSignature) {
+        /**
+         * GET /member/{memberId}
+         * GET /ticket/{memberId}
+         */
+        String path = httpRequestSignature.path();
+        String httpMethod = httpRequestSignature.httpMethod();
+
+        return isSupportedPath(path, httpMethod);
+    }
+
+    @Override
+    public ApiGatewayLambdaResponse execute(APIGatewayV2HTTPEvent event, UserContext userContext) {
+        /**
+         * 1. event => 요청한 memberId 추출
+         * 2. UserContext 에서 실제 memberId 추출
+         * 3. 동일한지 확인
+         */
+        Long targetMemberId = extractAuthorizationTargetId(event);
+        Long myMemberId = userContext.getMemberId();
+
+        if (targetMemberId == myMemberId) {
+            return ApiGatewayLambdaResponse.successOf(myMemberId);
+        }
+        throw new OwnerMismatchException("you are not owner of this resource");
+    }
+
+    private static boolean isSupportedPath(String path, String httpMethod) {
+        boolean startCondition = (path.startsWith(MEMBER_SERVICE.getPrefix()) || path.startsWith(TICKET_SERVICE.getPrefix())) && httpMethod.equals("GET");
+        boolean hasOnlyOnePathVariable = Arrays.stream(path.split("/"))
+                .filter(element -> element.matches("\\d+"))
+                .limit(2)
+                .count() == 1;
+        return startCondition && hasOnlyOnePathVariable;
+    }
+
+    private static Long extractAuthorizationTargetId(APIGatewayV2HTTPEvent event) {
+        String rawPath = event.getRawPath();
+        return Arrays.stream(rawPath.split("/"))
+                .filter(element -> element.matches("\\d+")) //숫자만 필터링
+                .map(Long::parseLong)
+                .findFirst()
+                .get();
+    }
+}


### PR DESCRIPTION
-  OwnerCheckValidator에서  Owner불일치시 OwnerMismatchException throw
-  GlobalExceptionHandler에서 aop로 예외 처리
-  [MicroServicesConstants] 요청 path를 enum타입으로 변경
- [OwnerCheckValidator] 요청한 path에 포함된 memberId와 userContext의 memberId가 일치하는지 검증