### PR TITLE
[상품] 상품정보 무한 스크롤링을 위한 페이징 처리 로직 변경

### DIFF
--- a/prize/src/main/java/ddalkak/prize/config/error/GlobalExceptionHandler.java
+++ b/prize/src/main/java/ddalkak/prize/config/error/GlobalExceptionHandler.java
@@ -1,18 +1,20 @@
 package ddalkak.prize.config.error;
 
 
-import ddalkak.prize.config.error.exception.*;
+import ddalkak.prize.config.error.exception.BusinessBaseException;
+import ddalkak.prize.config.error.exception.PageOutOfBoundsException;
+import ddalkak.prize.config.error.exception.PrizeNotFoundException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
-@ControllerAdvice // 모든 컨트롤러에서 발생하는 예외를 잡아서 처리
+@RestControllerAdvice // 모든 컨트롤러에서 발생하는 예외를 잡아서 처리
 public class GlobalExceptionHandler {
     // 지원하지 않은 HTTP method 호출 할 경우 발생
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class) // HttpRequestMethodNotSupportedException 예외를 잡아서 처리

--- a/prize/src/main/java/ddalkak/prize/controller/PrizeController.java
+++ b/prize/src/main/java/ddalkak/prize/controller/PrizeController.java
@@ -1,8 +1,10 @@
 package ddalkak.prize.controller;
 
 import ddalkak.prize.dto.request.PrizeSaveRequestDto;
-import ddalkak.prize.dto.response.PrizeResponseDto;
+import ddalkak.prize.dto.response.AdminPrizeResponseDto;
 import ddalkak.prize.dto.request.PrizeUpdateRequestDto;
+import ddalkak.prize.dto.response.PageResponseDto;
+import ddalkak.prize.dto.response.PrizeResponseDto;
 import ddalkak.prize.service.prize.PrizeService;
 
 import jakarta.validation.Valid;
@@ -16,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/prize")
+@RequestMapping("/prizes")
 @RequiredArgsConstructor
 @Validated
 public class PrizeController {
@@ -30,17 +32,18 @@ public class PrizeController {
 
     }
     @GetMapping
-    public ResponseEntity< List<PrizeResponseDto> > getPrizePage (
-        @PositiveOrZero(message = "처음 페이지입니다.") @RequestParam(defaultValue = "0") int page,
-        @Positive(message = "요청 데이터수는 1개 이상이어야 합니다.") @RequestParam(defaultValue = "5") int size )
+    public ResponseEntity<PageResponseDto> getPrizePage (
+        @Positive(message = "요청 데이터수는 1개 이상이어야 합니다.") @RequestParam(defaultValue = "5") int size,
+        @RequestParam Long lastId
+    )
     {
-        return ResponseEntity.ok(prizeService.getPrizePage(page, size).getContent());
+        return ResponseEntity.ok(prizeService.getPrizePage(size, lastId));
     }
 
 
 
     @GetMapping("/{id}")
-    public ResponseEntity<PrizeResponseDto> getPrize(@PathVariable Long id) {
+    public ResponseEntity<AdminPrizeResponseDto> getPrize(@PathVariable Long id) {
         return ResponseEntity.ok(prizeService.getPrize(id));
     }
     @PatchMapping

--- a/prize/src/main/java/ddalkak/prize/domain/entity/Prize.java
+++ b/prize/src/main/java/ddalkak/prize/domain/entity/Prize.java
@@ -1,11 +1,15 @@
 package ddalkak.prize.domain.entity;
 
+import ddalkak.prize.dto.request.PrizeSaveRequestDto;
+import ddalkak.prize.service.util.RandomNumberGenerator;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 
 @Entity
 @Getter
-public class Prize extends BaseEntity{
+public class Prize extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -21,6 +25,12 @@ public class Prize extends BaseEntity{
     @Column(nullable = false)
     private Integer price;
 
+    @Column
+    private String imageUrl;
+
+    @Column
+    @Lob
+    private String description;
 
     @Column
     private Long probabilityRange;
@@ -31,23 +41,38 @@ public class Prize extends BaseEntity{
     @Version
     private Long version;
 
-    public Prize( String name, Integer quantity, Integer price, Long probabilityRange, Long randomNumber) {
+    public static Prize from(PrizeSaveRequestDto prizeSaveRequestDto) {
+        return Prize.builder()
+                .name(prizeSaveRequestDto.name())
+                .price(prizeSaveRequestDto.price())
+                .description(prizeSaveRequestDto.description())
+                .imageUrl(prizeSaveRequestDto.imageUrl())
+                .quantity(prizeSaveRequestDto.quantity())
+                .randomNumber(RandomNumberGenerator.ofRange(prizeSaveRequestDto.probabilityRange()))
+                .probabilityRange(prizeSaveRequestDto.probabilityRange())
+                .build();
+    }
 
+    @Builder(access = AccessLevel.PRIVATE)
+    private Prize(String name, Integer quantity, Integer price, Long probabilityRange, Long randomNumber, String description, String imageUrl) {
         this.name = name;
         this.quantity = quantity;
         this.price = price;
         this.probabilityRange = probabilityRange;
         this.randomNumber = randomNumber;
-
+        this.description = description;
+        this.imageUrl = imageUrl;
     }
 
     public Prize() {
 
     }
 
-    public void update(  String name, Integer quantity, Integer price ) {
-        if(name!= null) this.name = name;
-        if(quantity != null) this.quantity = quantity;
-        if(price != null) this.price = price;
+    public void update(String name, Integer quantity, Integer price) {
+        if (name != null) this.name = name;
+        if (quantity != null) this.quantity = quantity;
+        if (price != null) this.price = price;
     }
+
+
 }

--- a/prize/src/main/java/ddalkak/prize/dto/request/PrizeSaveRequestDto.java
+++ b/prize/src/main/java/ddalkak/prize/dto/request/PrizeSaveRequestDto.java
@@ -1,6 +1,8 @@
 package ddalkak.prize.dto.request;
 
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Lob;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -17,6 +19,9 @@ public record PrizeSaveRequestDto(
         @PositiveOrZero@NotNull
         Integer price,
         @Positive@NotNull
-        Long probabilityRange
+        Long probabilityRange,
+        @NotNull
+        String imageUrl,
+        String description
 
 ){ }

--- a/prize/src/main/java/ddalkak/prize/dto/request/PrizeUpdateRequestDto.java
+++ b/prize/src/main/java/ddalkak/prize/dto/request/PrizeUpdateRequestDto.java
@@ -15,4 +15,5 @@ public record PrizeUpdateRequestDto(
         @Positive
         Integer price
 ) {
+
 }

--- a/prize/src/main/java/ddalkak/prize/dto/response/AdminPrizeResponseDto.java
+++ b/prize/src/main/java/ddalkak/prize/dto/response/AdminPrizeResponseDto.java
@@ -5,24 +5,28 @@ import lombok.AccessLevel;
 import lombok.Builder;
 
 @Builder(access = AccessLevel.PRIVATE)
-public record PrizeResponseDto(
-
-        long id,
+public record AdminPrizeResponseDto(
+        Long id,
         String name,
         String description,
         String imageUrl,
         Integer quantity,
-        Long probabilityRange
-
+        Integer price,
+        Long probabilityRange,
+        Long randomNumber
 ) {
-    public static PrizeResponseDto of(Prize prize){
-        return PrizeResponseDto.builder()
+    public static AdminPrizeResponseDto of(Prize prize) {
+        return AdminPrizeResponseDto.builder()
                 .id(prize.getId())
                 .name(prize.getName())
                 .description(prize.getDescription())
                 .imageUrl(prize.getImageUrl())
                 .quantity(prize.getQuantity())
+                .price(prize.getPrice())
                 .probabilityRange(prize.getProbabilityRange())
+                .randomNumber(prize.getRandomNumber())
                 .build();
+
     }
+
 }

--- a/prize/src/main/java/ddalkak/prize/dto/response/PageResponseDto.java
+++ b/prize/src/main/java/ddalkak/prize/dto/response/PageResponseDto.java
@@ -1,0 +1,16 @@
+package ddalkak.prize.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record PageResponseDto(List<PrizeResponseDto> data,
+                              boolean hasNext) {
+    public static PageResponseDto of(List<PrizeResponseDto> data, boolean hasNext) {
+        return PageResponseDto.builder()
+                .data(data)
+                .hasNext(hasNext)
+                .build();
+    }
+}

--- a/prize/src/main/java/ddalkak/prize/repository/prize/PrizeJpaRepository.java
+++ b/prize/src/main/java/ddalkak/prize/repository/prize/PrizeJpaRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface PrizeJpaRepository extends JpaRepository<Prize, Long> {
-    Page<Prize> findByQuantityGreaterThanOrderByIdDesc(Integer quantity , Pageable pageable);
+    Page<Prize> findByIdLessThanAndQuantityGreaterThanOrderByIdDesc(Long lastId, Integer quantity, Pageable pageable);
     Optional<Prize> findById(Long id);
 }

--- a/prize/src/main/java/ddalkak/prize/repository/prize/PrizeRepository.java
+++ b/prize/src/main/java/ddalkak/prize/repository/prize/PrizeRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 
 public interface PrizeRepository {
     Prize save(Prize prize);
-    Page<Prize> findAllByIdDesc(Pageable pageable);
+    Page<Prize> findAllByIdDesc(Long lastId,Pageable pageable);
     Optional<Prize> findById(Long id);
 }

--- a/prize/src/main/java/ddalkak/prize/repository/prize/impl/PrizeRepositoryImpl.java
+++ b/prize/src/main/java/ddalkak/prize/repository/prize/impl/PrizeRepositoryImpl.java
@@ -4,7 +4,6 @@ import ddalkak.prize.domain.entity.Prize;
 import ddalkak.prize.repository.prize.PrizeJpaRepository;
 import ddalkak.prize.repository.prize.PrizeRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -23,8 +22,8 @@ public class PrizeRepositoryImpl implements PrizeRepository {
     }
 
     @Override
-    public Page<Prize> findAllByIdDesc(Pageable pageable) {
-        return prizeJpaRepository.findByQuantityGreaterThanOrderByIdDesc(0 , pageable);
+    public Page<Prize> findAllByIdDesc(Long lastId,Pageable pageable) {
+        return prizeJpaRepository.findByIdLessThanAndQuantityGreaterThanOrderByIdDesc(lastId ,0 , pageable);
     }
 
     @Override

--- a/prize/src/main/java/ddalkak/prize/service/prize/PrizeService.java
+++ b/prize/src/main/java/ddalkak/prize/service/prize/PrizeService.java
@@ -1,15 +1,17 @@
 package ddalkak.prize.service.prize;
 
 
-import ddalkak.prize.dto.response.PrizeResponseDto;
+import ddalkak.prize.dto.response.AdminPrizeResponseDto;
 import ddalkak.prize.dto.request.PrizeSaveRequestDto;
 import ddalkak.prize.dto.request.PrizeUpdateRequestDto;
+import ddalkak.prize.dto.response.PageResponseDto;
+import ddalkak.prize.dto.response.PrizeResponseDto;
 import org.springframework.data.domain.Page;
 
 public interface PrizeService {
     Long save(PrizeSaveRequestDto prizeSaveRequestDto);
-    Page<PrizeResponseDto> getPrizePage(int page, int size);
-    PrizeResponseDto getPrize(Long id);
+    PageResponseDto getPrizePage( int size, Long lastId);
+    AdminPrizeResponseDto getPrize(Long id);
     Long updatePrize(PrizeUpdateRequestDto prizeUpdateRequestDto);
     void decreaseStock(Long prizeId);
 

--- a/prize/src/main/java/ddalkak/prize/service/prize/impl/PrizeServiceImpl.java
+++ b/prize/src/main/java/ddalkak/prize/service/prize/impl/PrizeServiceImpl.java
@@ -4,13 +4,13 @@ import ddalkak.prize.config.error.exception.OutOfStockException;
 import ddalkak.prize.config.error.exception.PageOutOfBoundsException;
 import ddalkak.prize.config.error.exception.PrizeNotFoundException;
 import ddalkak.prize.domain.entity.Prize;
-import ddalkak.prize.dto.response.PrizeResponseDto;
 import ddalkak.prize.dto.request.PrizeSaveRequestDto;
 import ddalkak.prize.dto.request.PrizeUpdateRequestDto;
+import ddalkak.prize.dto.response.AdminPrizeResponseDto;
+import ddalkak.prize.dto.response.PageResponseDto;
+import ddalkak.prize.dto.response.PrizeResponseDto;
 import ddalkak.prize.repository.prize.PrizeRepository;
 import ddalkak.prize.service.prize.PrizeService;
-import ddalkak.prize.service.util.RandomNumberGenerator;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -18,6 +18,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -37,20 +40,8 @@ public class PrizeServiceImpl implements PrizeService {
     @Transactional
     public Long save(PrizeSaveRequestDto prizeSaveRequestDto) {
         log.info("Saving new prize: {}", prizeSaveRequestDto.name());
-        // 난수 생성
-        Long randomNumber = RandomNumberGenerator.ofRange(prizeSaveRequestDto.probabilityRange());
-
-        Prize prize = new Prize(
-                prizeSaveRequestDto.name(),
-                prizeSaveRequestDto.quantity(),
-                prizeSaveRequestDto.price(),
-                prizeSaveRequestDto.probabilityRange(),
-                randomNumber
-        );
-
         // 엔티티 저장
-        Prize savedPrize = prizeRepository.save(prize);
-
+        Prize savedPrize = prizeRepository.save(Prize.from(prizeSaveRequestDto));
         // 저장된 엔티티의 ID 반환
         return savedPrize.getId();
     }
@@ -59,24 +50,27 @@ public class PrizeServiceImpl implements PrizeService {
     /**
      * 페이지네이션된 상품 목록을 조회합니다.
      *
-     * @param page 페이지 번호
      * @param size 페이지 크기
      * @return 상품 응답 DTO 페이지
      * @throws PageOutOfBoundsException 페이지 번호가 범위를 벗어난 경우
      */
 
     @Override
-    public Page<PrizeResponseDto> getPrizePage(int page, int size) {
-        log.info("Fetching prize page: {}, size: {}", page, size);
-        Pageable pageable = Pageable.ofSize(size).withPage(page);
-        Page<PrizeResponseDto> resultPage = prizeRepository.findAllByIdDesc(pageable)
-                .map(PrizeResponseDto::new);
-        if(page >= resultPage.getTotalPages() && resultPage.getTotalPages() >= 0) {
-           throw new PageOutOfBoundsException();
-        }
-        return resultPage;
+    public PageResponseDto getPrizePage(int size, Long lastId) {
+        Pageable pageable = Pageable.ofSize(size + 1);
+        List<PrizeResponseDto> resultPage = prizeRepository.findAllByIdDesc(lastId, pageable)
+                .map(prize -> PrizeResponseDto.of(prize))
+                .getContent();
+        boolean hasNext = resultPage.size() == size + 1;
 
+
+        return PageResponseDto.of(
+                resultPage.stream()
+                        .limit(size)
+                        .collect(Collectors.toList()),
+                hasNext);
     }
+
     /**
      * ID로 상품을 조회합니다.
      *
@@ -86,12 +80,13 @@ public class PrizeServiceImpl implements PrizeService {
      */
 
     @Override
-    public PrizeResponseDto getPrize(Long id) {
+    public AdminPrizeResponseDto getPrize(Long id) {
         log.info("Fetching prize with id: {}", id);
         return prizeRepository.findById(id)
-                .map(PrizeResponseDto::new)
-                .orElseThrow( PrizeNotFoundException::new);
+                .map(prize -> AdminPrizeResponseDto.of(prize))
+                .orElseThrow(PrizeNotFoundException::new);
     }
+
     /**
      * 상품 정보를 업데이트합니다.
      *
@@ -103,22 +98,21 @@ public class PrizeServiceImpl implements PrizeService {
     @Transactional
     public Long updatePrize(PrizeUpdateRequestDto prizeUpdateRequestDto) {
         log.info("Updating prize with id: {}", prizeUpdateRequestDto.id());
-       Prize prize = prizeRepository.findById(prizeUpdateRequestDto.id())
-               .orElseThrow(PrizeNotFoundException::new);
-       prize.update(
-               prizeUpdateRequestDto.name(),
-               prizeUpdateRequestDto.quantity(),
-               prizeUpdateRequestDto.price()
-       );
-       return prize.getId();
+        Prize prize = prizeRepository.findById(prizeUpdateRequestDto.id())
+                .orElseThrow(PrizeNotFoundException::new);
+        prize.update(
+                prizeUpdateRequestDto.name(),
+                prizeUpdateRequestDto.quantity(),
+                prizeUpdateRequestDto.price()
+        );
+        return prize.getId();
     }
+
     /**
      * 상품의 재고를 감소시킵니다.
      *
      * @param prizeId 상품 ID
      * @throws PrizeNotFoundException 상품을 찾을 수 없는 경우
-     *
-     *
      */
     // 재고 감소 메서드
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -126,9 +120,9 @@ public class PrizeServiceImpl implements PrizeService {
         Prize prize = prizeRepository.findById(prizeId)
                 .orElseThrow(PrizeNotFoundException::new);
         if (prize.getQuantity() <= 0) {
-           throw new OutOfStockException();
+            throw new OutOfStockException();
         } else {
-           prize.update(null,prize.getQuantity() - 1, null);
+            prize.update(null, prize.getQuantity() - 1, null);
         }
 
     }


### PR DESCRIPTION
- [prize] imageUrl, description 필드 추가
- [prizeResponseDto] -> [AdminPrizeResponseDto, PrizeResponseDto] 로 분리
- [PageResponseDto] 페이징 처리 응답을 담고있는 dto
- [PrizeJpaRepository] 페이징처리를 cursor 방식으로 변경

*  + 객체들의 생성방식을 정적팩토리메서드 방식으로 변경했습니다.