### PR TITLE
refactor: controller의 getPrizePage 첫 요청시 가장 큰 id 값을 가진 상품부터 가져오게 수정

### DIFF
--- a/prize/src/main/java/ddalkak/prize/controller/PrizeController.java
+++ b/prize/src/main/java/ddalkak/prize/controller/PrizeController.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,7 +35,7 @@ public class PrizeController {
     @GetMapping
     public ResponseEntity<PageResponseDto> getPrizePage (
         @Positive(message = "요청 데이터수는 1개 이상이어야 합니다.") @RequestParam(defaultValue = "5") int size,
-        @RequestParam Long lastId
+        @RequestParam @Nullable Long lastId
     )
     {
         return ResponseEntity.ok(prizeService.getPrizePage(size, lastId));

--- a/prize/src/main/java/ddalkak/prize/repository/prize/PrizeJpaRepository.java
+++ b/prize/src/main/java/ddalkak/prize/repository/prize/PrizeJpaRepository.java
@@ -9,5 +9,7 @@ import java.util.Optional;
 
 public interface PrizeJpaRepository extends JpaRepository<Prize, Long> {
     Page<Prize> findByIdLessThanAndQuantityGreaterThanOrderByIdDesc(Long lastId, Integer quantity, Pageable pageable);
+    Page<Prize> findByQuantityGreaterThanOrderByIdDesc(Integer quantity, Pageable pageable);
     Optional<Prize> findById(Long id);
+
 }

--- a/prize/src/main/java/ddalkak/prize/repository/prize/PrizeRepository.java
+++ b/prize/src/main/java/ddalkak/prize/repository/prize/PrizeRepository.java
@@ -9,5 +9,7 @@ import java.util.Optional;
 public interface PrizeRepository {
     Prize save(Prize prize);
     Page<Prize> findAllByIdDesc(Long lastId,Pageable pageable);
+    Page<Prize> findAllByIdDesc(Pageable pageable);
     Optional<Prize> findById(Long id);
+
 }

--- a/prize/src/main/java/ddalkak/prize/repository/prize/impl/PrizeRepositoryImpl.java
+++ b/prize/src/main/java/ddalkak/prize/repository/prize/impl/PrizeRepositoryImpl.java
@@ -25,10 +25,15 @@ public class PrizeRepositoryImpl implements PrizeRepository {
     public Page<Prize> findAllByIdDesc(Long lastId,Pageable pageable) {
         return prizeJpaRepository.findByIdLessThanAndQuantityGreaterThanOrderByIdDesc(lastId ,0 , pageable);
     }
+    @Override
+    public Page<Prize> findAllByIdDesc(Pageable pageable) {
+        return prizeJpaRepository.findByQuantityGreaterThanOrderByIdDesc(0 , pageable);
+    }
 
     @Override
     public Optional<Prize> findById(Long id) {
         return prizeJpaRepository.findById(id);
     }
+
 
 }

--- a/prize/src/main/java/ddalkak/prize/service/prize/impl/PrizeServiceImpl.java
+++ b/prize/src/main/java/ddalkak/prize/service/prize/impl/PrizeServiceImpl.java
@@ -58,12 +58,22 @@ public class PrizeServiceImpl implements PrizeService {
     @Override
     public PageResponseDto getPrizePage(int size, Long lastId) {
         Pageable pageable = Pageable.ofSize(size + 1);
+        // 처음 요청은 가장 큰 id 부터
+        if (lastId == null) {
+            List<PrizeResponseDto> resultPage = prizeRepository.findAllByIdDesc(pageable)
+                    .map(prize -> PrizeResponseDto.of(prize))
+                    .getContent();
+            boolean hasNext = resultPage.size() == size + 1;
+            return PageResponseDto.of(
+                    resultPage.stream()
+                            .limit(size)
+                            .collect(Collectors.toList()),
+                    hasNext);
+        }
         List<PrizeResponseDto> resultPage = prizeRepository.findAllByIdDesc(lastId, pageable)
                 .map(prize -> PrizeResponseDto.of(prize))
                 .getContent();
         boolean hasNext = resultPage.size() == size + 1;
-
-
         return PageResponseDto.of(
                 resultPage.stream()
                         .limit(size)

--- a/prize/src/main/java/ddalkak/prize/service/prize/impl/PrizeServiceImpl.java
+++ b/prize/src/main/java/ddalkak/prize/service/prize/impl/PrizeServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 
@@ -54,25 +55,11 @@ public class PrizeServiceImpl implements PrizeService {
      * @return 상품 응답 DTO 페이지
      * @throws PageOutOfBoundsException 페이지 번호가 범위를 벗어난 경우
      */
-
     @Override
+    @Transactional(readOnly = true)
     public PageResponseDto getPrizePage(int size, Long lastId) {
         Pageable pageable = Pageable.ofSize(size + 1);
-        // 처음 요청은 가장 큰 id 부터
-        if (lastId == null) {
-            List<PrizeResponseDto> resultPage = prizeRepository.findAllByIdDesc(pageable)
-                    .map(prize -> PrizeResponseDto.of(prize))
-                    .getContent();
-            boolean hasNext = resultPage.size() == size + 1;
-            return PageResponseDto.of(
-                    resultPage.stream()
-                            .limit(size)
-                            .collect(Collectors.toList()),
-                    hasNext);
-        }
-        List<PrizeResponseDto> resultPage = prizeRepository.findAllByIdDesc(lastId, pageable)
-                .map(prize -> PrizeResponseDto.of(prize))
-                .getContent();
+        List<PrizeResponseDto> resultPage = getResultPage(lastId, pageable);
         boolean hasNext = resultPage.size() == size + 1;
         return PageResponseDto.of(
                 resultPage.stream()
@@ -135,6 +122,17 @@ public class PrizeServiceImpl implements PrizeService {
             prize.update(null, prize.getQuantity() - 1, null);
         }
 
+    }
+
+    private List<PrizeResponseDto> getResultPage(Long lastId, Pageable pageable) {
+        if (lastId == null) {
+            return prizeRepository.findAllByIdDesc(pageable)
+                    .map(prize -> PrizeResponseDto.of(prize))
+                    .getContent();
+        }
+        return prizeRepository.findAllByIdDesc(lastId, pageable)
+                .map(prize -> PrizeResponseDto.of(prize))
+                .getContent();
     }
 
 }


### PR DESCRIPTION
- 요청 파라미터의 lastId가 null인 경우(첫 렌더링용 요청) 메서드 오버로딩으로 분기 처리
- 테이블의 가장 큰 id값을 가진 상품 엔티티부터 가져오게 수정