### PR TITLE
[배포] 배포환경 쿠키 이슈 해결

### DIFF
--- a/member/src/main/java/ddalkak/member/controller/AuthController.java
+++ b/member/src/main/java/ddalkak/member/controller/AuthController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.Duration;
 
+import static ddalkak.member.domain.JwtConstants.*;
+
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -30,8 +32,8 @@ public class AuthController {
     public ResponseEntity<Void> refreshLogin(@CookieValue(value = "refreshToken") final String refreshToken) {
         Jwt newJwt = authService.refreshLogin(refreshToken);
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, createCookie(newJwt.accessToken(), JwtConstants.ACCESS_TOKEN))
-                .header(HttpHeaders.SET_COOKIE, createCookie(newJwt.refreshToken(), JwtConstants.REFRESH_TOKEN))
+                .header(ACCESS_TOKEN.getHttpHeader(), createCookie(newJwt.accessToken(), ACCESS_TOKEN))
+                .header(REFRESH_TOKEN.getHttpHeader(), createCookie(newJwt.refreshToken(), REFRESH_TOKEN))
                 .build();
     }
 

--- a/member/src/main/java/ddalkak/member/domain/JwtConstants.java
+++ b/member/src/main/java/ddalkak/member/domain/JwtConstants.java
@@ -8,9 +8,10 @@ import java.time.Duration;
 @RequiredArgsConstructor
 @Getter
 public enum JwtConstants {
-    ACCESS_TOKEN("accessToken", Duration.ofHours(1)),
-    REFRESH_TOKEN("refreshToken", Duration.ofDays(14));
+    ACCESS_TOKEN("accessToken", Duration.ofHours(1), "x-access-token"),
+    REFRESH_TOKEN("refreshToken", Duration.ofDays(14), "x-refresh-token");
 
     private final String key;
     private final Duration duration;
+    private final String httpHeader;
 }

--- a/member/src/main/java/ddalkak/member/dto/response/LoginResponse.java
+++ b/member/src/main/java/ddalkak/member/dto/response/LoginResponse.java
@@ -1,18 +1,23 @@
 package ddalkak.member.dto.response;
 
+import ddalkak.member.domain.MemberType;
 import ddalkak.member.domain.entity.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
 
+import java.util.List;
+
 @Builder(access = AccessLevel.PRIVATE)
 public record LoginResponse(Long memberId,
                             String name,
-                            String email) {
+                            String email,
+                            List<MemberType> roles) {
     public static LoginResponse from(Member member) {
         return LoginResponse.builder()
                 .memberId(member.getMemberId())
                 .name(member.getName())
                 .email(member.getEmail())
+                .roles(member.getRoles())
                 .build();
     }
 }

--- a/member/src/main/java/ddalkak/member/service/auth/CustomAuthenticationSuccessHandler.java
+++ b/member/src/main/java/ddalkak/member/service/auth/CustomAuthenticationSuccessHandler.java
@@ -27,6 +27,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import java.io.IOException;
 
+import static ddalkak.member.domain.JwtConstants.*;
+
 @RequiredArgsConstructor
 @Component
 @Slf4j
@@ -73,8 +75,8 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
     }
 
     private void setLoginSuccessResponse(HttpServletResponse response, Member loginMember, Jwt jwt) {
-        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(jwt.accessToken(), JwtConstants.ACCESS_TOKEN));
-        response.addHeader(HttpHeaders.SET_COOKIE, createCookie(jwt.refreshToken(), JwtConstants.REFRESH_TOKEN));
+        response.addHeader(ACCESS_TOKEN.getHttpHeader(), createCookie(jwt.accessToken(), ACCESS_TOKEN));
+        response.addHeader(REFRESH_TOKEN.getHttpHeader(), createCookie(jwt.refreshToken(), REFRESH_TOKEN));
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
         try {


### PR DESCRIPTION
- AWS API GW(REST API)에서 두 개의 'Set-Cookie' 헤더를 인식하지 못하는 문제가 존재
- 따라서 각 토큰을 별도의 커스텀 헤더로 정의해 반환하고, API GW를 지나 CloudFront 레이어에서 두 개의 Set-Cookie 헤더로 다시 변환해 클라이언트에게 최종 응답하는 형태로 수정