### PR TITLE
API GW 500 응답 이슈 해결

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -38,8 +38,6 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // AWS Lambda
-    implementation 'org.springframework.cloud:spring-cloud-function-adapter-aws:4.1.0'
-    implementation 'org.springframework.cloud:spring-cloud-starter-function-web:4.1.0'
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.3'
     implementation 'com.amazonaws:aws-lambda-java-events:3.14.0'
 

--- a/auth/src/main/java/ddalkak/auth/common/aop/annotation/ExceptionCatcher.java
+++ b/auth/src/main/java/ddalkak/auth/common/aop/annotation/ExceptionCatcher.java
@@ -1,4 +1,4 @@
-package ddalkak.auth.aop.annotation;
+package ddalkak.auth.common.aop.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/auth/src/main/java/ddalkak/auth/common/aop/aspect/GlobalExceptionHandler.java
+++ b/auth/src/main/java/ddalkak/auth/common/aop/aspect/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package ddalkak.auth.aop.aspect;
+package ddalkak.auth.common.aop.aspect;
 
 import ddalkak.auth.common.exception.OwnerMismatchException;
 import ddalkak.auth.common.exception.RoleMismatchException;
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Slf4j
 public class GlobalExceptionHandler {
-    @Around("@annotation(ddalkak.auth.aop.annotation.ExceptionCatcher)")
+    @Around("@annotation(ddalkak.auth.common.aop.annotation.ExceptionCatcher)")
     public Object handleException(ProceedingJoinPoint joinPoint) throws Throwable {
         try {
             return joinPoint.proceed();
@@ -38,6 +38,9 @@ public class GlobalExceptionHandler {
         } catch (OwnerMismatchException e) {
             log.info("Is Not Owner", e);
             return ApiGatewayLambdaResponse.errorOf("MISMATCH_OWNER");
+        } catch (Exception e) {
+            log.info("Unexpected Exception", e);
+            return ApiGatewayLambdaResponse.errorOf("UNEXPECTED");
         }
     }
 }

--- a/auth/src/main/java/ddalkak/auth/common/config/SupportedValidatorConfig.java
+++ b/auth/src/main/java/ddalkak/auth/common/config/SupportedValidatorConfig.java
@@ -1,8 +1,8 @@
-package ddalkak.auth.config;
+package ddalkak.auth.common.config;
 
-import ddalkak.auth.validator.AdminValidator;
-import ddalkak.auth.validator.OwnerCheckValidator;
-import ddalkak.auth.validator.Validator;
+import ddalkak.auth.service.validator.AdminValidator;
+import ddalkak.auth.service.validator.OwnerCheckValidator;
+import ddalkak.auth.service.validator.Validator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/auth/src/main/java/ddalkak/auth/dto/ApiGatewayLambdaResponse.java
+++ b/auth/src/main/java/ddalkak/auth/dto/ApiGatewayLambdaResponse.java
@@ -2,22 +2,13 @@ package ddalkak.auth.dto;
 
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@Getter
-public class ApiGatewayLambdaResponse {
-    private boolean isAuthorized;
-    private Map<String, Object> context;
-
-    @Builder(access = AccessLevel.PRIVATE)
-    public ApiGatewayLambdaResponse(boolean isAuthorized, Map<String, Object> context) {
-        this.isAuthorized = isAuthorized;
-        this.context = context;
-    }
-
+@Builder(access = AccessLevel.PRIVATE)
+public record ApiGatewayLambdaResponse(boolean isAuthorized,
+                                       Map<String, Object> context) {
     public static ApiGatewayLambdaResponse successOf(Long memberId) {
         ApiGatewayLambdaResponse response = ApiGatewayLambdaResponse.builder()
                 .isAuthorized(true)
@@ -38,7 +29,7 @@ public class ApiGatewayLambdaResponse {
 
 
     private void addErrorMessage(String message) {
-        this.context.put("message", message);
+        this.context.put("errorMessage", message);
     }
 
     private void addMemberId(Long memberId) {

--- a/auth/src/main/java/ddalkak/auth/listener/LambdaEventListener.java
+++ b/auth/src/main/java/ddalkak/auth/listener/LambdaEventListener.java
@@ -1,53 +1,29 @@
 package ddalkak.auth.listener;
 
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
-import ddalkak.auth.aop.annotation.ExceptionCatcher;
-import ddalkak.auth.common.service.JwtService;
-import ddalkak.auth.dto.HttpRequestSignature;
-import ddalkak.auth.dto.UserContext;
+import ddalkak.auth.AuthApplication;
 import ddalkak.auth.dto.ApiGatewayLambdaResponse;
-import ddalkak.auth.validator.ValidationAdapter;
-import lombok.RequiredArgsConstructor;
+import ddalkak.auth.service.UserAuthorizer;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
 
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-@Component
 @Slf4j
-@RequiredArgsConstructor
-public class LambdaEventListener implements Function<APIGatewayV2HTTPEvent, ApiGatewayLambdaResponse> {
-    private final JwtService jwtService;
-    private final ValidationAdapter adapter;
+public class LambdaEventListener implements RequestHandler<APIGatewayV2HTTPEvent, ApiGatewayLambdaResponse> {
+    private final UserAuthorizer userAuthorizer;
+
+    public LambdaEventListener() {
+        ConfigurableApplicationContext context = new SpringApplicationBuilder(AuthApplication.class)
+                .web(WebApplicationType.NONE)
+                .run();
+        userAuthorizer = context.getBean(UserAuthorizer.class);
+    }
 
     @Override
-    @ExceptionCatcher
-    public ApiGatewayLambdaResponse apply(APIGatewayV2HTTPEvent event) {
-        // 내부적으로 access token 검증 (Invalid, Expired 등 공통 검증)
-        UserContext userContext = jwtService.extractUserContext(extractAccessToken(event));
-
-        HttpRequestSignature httpRequestSignature = HttpRequestSignature.of(
-                event.getRawPath(),
-                event.getRequestContext().getHttp().getMethod()
-        );
-        return adapter.selectValidator(httpRequestSignature)
-                .map(validator -> validator.execute(event, userContext))
-                .orElseGet(() -> ApiGatewayLambdaResponse.successOf(userContext.getMemberId())); // 추가 인가 과정이 필요 없는 경우 성공 응답
-    }
-
-    private String extractAccessToken(APIGatewayV2HTTPEvent event) {
-        Map<String, String> cookies = parseCookies(event.getCookies());
-        String accessToken = cookies.get("accessToken");
-        return accessToken;
-    }
-
-    private Map<String, String> parseCookies(List<String> cookies) {
-        return cookies.stream()
-                .map(cookie -> cookie.split("=", 2))
-                .filter(parts -> parts.length == 2)
-                .collect(Collectors.toMap(parts -> parts[0], parts -> parts[1]));
+    public ApiGatewayLambdaResponse handleRequest(APIGatewayV2HTTPEvent event, Context context) {
+        return userAuthorizer.execute(event);
     }
 }

--- a/auth/src/main/java/ddalkak/auth/service/JwtService.java
+++ b/auth/src/main/java/ddalkak/auth/service/JwtService.java
@@ -1,4 +1,4 @@
-package ddalkak.auth.common.service;
+package ddalkak.auth.service;
 
 import ddalkak.auth.common.exception.RoleMismatchException;
 import ddalkak.auth.dto.UserContext;

--- a/auth/src/main/java/ddalkak/auth/service/UserAuthorizer.java
+++ b/auth/src/main/java/ddalkak/auth/service/UserAuthorizer.java
@@ -1,0 +1,50 @@
+package ddalkak.auth.service;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+import ddalkak.auth.common.aop.annotation.ExceptionCatcher;
+import ddalkak.auth.dto.ApiGatewayLambdaResponse;
+import ddalkak.auth.dto.HttpRequestSignature;
+import ddalkak.auth.dto.UserContext;
+import ddalkak.auth.service.validator.ValidationAdapter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserAuthorizer {
+    private final JwtService jwtService;
+    private final ValidationAdapter adapter;
+
+    @ExceptionCatcher
+    public ApiGatewayLambdaResponse execute(APIGatewayV2HTTPEvent event) {
+        //      내부적으로 access token 검증 (Invalid, Expired 등 공통 검증)
+        UserContext userContext = jwtService.extractUserContext(extractAccessToken(event));
+
+        HttpRequestSignature httpRequestSignature = HttpRequestSignature.of(
+                event.getRawPath(),
+                event.getRequestContext().getHttp().getMethod()
+        );
+
+        adapter.selectValidator(httpRequestSignature)
+                .ifPresent(validator -> validator.execute(event, userContext));
+        return ApiGatewayLambdaResponse.successOf(userContext.getMemberId());
+    }
+
+    private String extractAccessToken(APIGatewayV2HTTPEvent event) {
+        Map<String, String> cookies = parseCookies(event.getCookies());
+        return cookies.get("accessToken");
+    }
+
+    private Map<String, String> parseCookies(List<String> cookies) {
+        return cookies.stream()
+                .map(cookie -> cookie.split("=", 2))
+                .filter(parts -> parts.length == 2)
+                .collect(Collectors.toMap(parts -> parts[0], parts -> parts[1]));
+    }
+}

--- a/auth/src/main/java/ddalkak/auth/service/validator/AdminValidator.java
+++ b/auth/src/main/java/ddalkak/auth/service/validator/AdminValidator.java
@@ -1,8 +1,7 @@
-package ddalkak.auth.validator;
+package ddalkak.auth.service.validator;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
-import ddalkak.auth.common.service.JwtService;
-import ddalkak.auth.dto.ApiGatewayLambdaResponse;
+import ddalkak.auth.service.JwtService;
 import ddalkak.auth.dto.HttpRequestSignature;
 import ddalkak.auth.dto.UserContext;
 import lombok.RequiredArgsConstructor;
@@ -27,8 +26,7 @@ public class AdminValidator implements Validator {
     }
 
     @Override
-    public ApiGatewayLambdaResponse execute(APIGatewayV2HTTPEvent event, UserContext userContext) {
+    public void execute(APIGatewayV2HTTPEvent event, UserContext userContext) {
         jwtService.validateAdmin(userContext.getRoles());
-        return ApiGatewayLambdaResponse.successOf(userContext.getMemberId());
     }
 }

--- a/auth/src/main/java/ddalkak/auth/service/validator/OwnerCheckValidator.java
+++ b/auth/src/main/java/ddalkak/auth/service/validator/OwnerCheckValidator.java
@@ -1,10 +1,10 @@
-package ddalkak.auth.validator;
+package ddalkak.auth.service.validator;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
 import ddalkak.auth.common.exception.OwnerMismatchException;
-import ddalkak.auth.dto.ApiGatewayLambdaResponse;
 import ddalkak.auth.dto.HttpRequestSignature;
 import ddalkak.auth.dto.UserContext;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
@@ -13,6 +13,7 @@ import static ddalkak.auth.enums.MicroServicesConstants.MEMBER_SERVICE;
 import static ddalkak.auth.enums.MicroServicesConstants.TICKET_SERVICE;
 
 @Component
+@Slf4j
 public class OwnerCheckValidator implements Validator {
 
     @Override
@@ -28,7 +29,7 @@ public class OwnerCheckValidator implements Validator {
     }
 
     @Override
-    public ApiGatewayLambdaResponse execute(APIGatewayV2HTTPEvent event, UserContext userContext) {
+    public void execute(APIGatewayV2HTTPEvent event, UserContext userContext) {
         /**
          * 1. event => 요청한 memberId 추출
          * 2. UserContext 에서 실제 memberId 추출
@@ -37,10 +38,9 @@ public class OwnerCheckValidator implements Validator {
         Long targetMemberId = extractAuthorizationTargetId(event);
         Long myMemberId = userContext.getMemberId();
 
-        if (targetMemberId == myMemberId) {
-            return ApiGatewayLambdaResponse.successOf(myMemberId);
+        if (targetMemberId != myMemberId) {
+            throw new OwnerMismatchException("you are not owner of this resource");
         }
-        throw new OwnerMismatchException("you are not owner of this resource");
     }
 
     private static boolean isSupportedPath(String path, String httpMethod) {
@@ -53,6 +53,7 @@ public class OwnerCheckValidator implements Validator {
     }
 
     private static Long extractAuthorizationTargetId(APIGatewayV2HTTPEvent event) {
+        log.info("start owner check validation");
         String rawPath = event.getRawPath();
         return Arrays.stream(rawPath.split("/"))
                 .filter(element -> element.matches("\\d+")) //숫자만 필터링

--- a/auth/src/main/java/ddalkak/auth/service/validator/ValidationAdapter.java
+++ b/auth/src/main/java/ddalkak/auth/service/validator/ValidationAdapter.java
@@ -1,4 +1,4 @@
-package ddalkak.auth.validator;
+package ddalkak.auth.service.validator;
 
 import ddalkak.auth.dto.HttpRequestSignature;
 import lombok.RequiredArgsConstructor;

--- a/auth/src/main/java/ddalkak/auth/service/validator/Validator.java
+++ b/auth/src/main/java/ddalkak/auth/service/validator/Validator.java
@@ -1,11 +1,10 @@
-package ddalkak.auth.validator;
+package ddalkak.auth.service.validator;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
 import ddalkak.auth.dto.HttpRequestSignature;
 import ddalkak.auth.dto.UserContext;
-import ddalkak.auth.dto.ApiGatewayLambdaResponse;
 
 public interface Validator {
     boolean supports(HttpRequestSignature httpRequestSignature);
-    ApiGatewayLambdaResponse execute(APIGatewayV2HTTPEvent event, UserContext userContext);
+    void execute(APIGatewayV2HTTPEvent event, UserContext userContext);
 }

--- a/auth/src/main/resources/application-prod.yml
+++ b/auth/src/main/resources/application-prod.yml
@@ -5,3 +5,11 @@ spring:
     activate:
       on-profile: prod
     import: aws-parameterstore:/config/auth_prod/
+  cloud:
+    function:
+      definition: lambdaEventListener
+logging:
+  level:
+    root: INFO
+jwt:
+  public_key: ${jwt_public_key}

--- a/auth/src/main/resources/application.yml
+++ b/auth/src/main/resources/application.yml
@@ -2,4 +2,4 @@ spring:
   application:
     name: auth
   profiles:
-    active: local
+    active: prod


### PR DESCRIPTION
- 원인: spring-cloud-function 의존성을 사용하면 최종 응답을 래핑해, 스펙이 맞지 않게 됨
- 해결: 따라서 의존성을 제거하고 aws lambda 측에서 listener를 직접 기본 생성자를 통해 호출하도록 수정
- 이에 따라 온전히 spring context를 활용하지 못하는 문제가 있었으나, listener를 람다 측 진입점 및 스프링 컨텍스트를 여는 지점으로 활용함
- 기본 생성자에서 스프링 컨텍스트를 실행하고 의존성을 주입받아 활용