### PR TITLE
Feature/prize idempotent consumer

### DIFF
--- a/prize/src/main/java/ddalkak/prize/aop/annotation/EnableIdempotent.java
+++ b/prize/src/main/java/ddalkak/prize/aop/annotation/EnableIdempotent.java
@@ -1,0 +1,12 @@
+package ddalkak.prize.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnableIdempotent {
+    String eventId();
+}

--- a/prize/src/main/java/ddalkak/prize/aop/aspect/CustomSpELParser.java
+++ b/prize/src/main/java/ddalkak/prize/aop/aspect/CustomSpELParser.java
@@ -1,0 +1,18 @@
+package ddalkak.prize.aop.aspect;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpELParser {
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/prize/src/main/java/ddalkak/prize/aop/aspect/EnableIdempotentAspect.java
+++ b/prize/src/main/java/ddalkak/prize/aop/aspect/EnableIdempotentAspect.java
@@ -1,0 +1,35 @@
+package ddalkak.prize.aop.aspect;
+
+import ddalkak.prize.aop.annotation.EnableIdempotent;
+import ddalkak.prize.service.proceededEvent.ProceededEventService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EnableIdempotentAspect {
+    private final ProceededEventService proceededEventService;
+
+    @Around("@annotation(ddalkak.prize.aop.annotation.EnableIdempotent)")
+    public void doIdempotent(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        EnableIdempotent annotation = method.getAnnotation(EnableIdempotent.class);
+        Long eventId = (Long) CustomSpELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), annotation.eventId());
+        if (proceededEventService.isProceededEvent(eventId)) {
+            log.info("이미 발행된 이벤트입니다.");
+            return;
+        }
+        joinPoint.proceed();
+        proceededEventService.save(eventId);
+    }
+}

--- a/prize/src/main/java/ddalkak/prize/domain/entity/ProceededEvent.java
+++ b/prize/src/main/java/ddalkak/prize/domain/entity/ProceededEvent.java
@@ -1,0 +1,31 @@
+package ddalkak.prize.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Entity
+public class ProceededEvent extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long eventId;
+
+    public static ProceededEvent from(Long eventId) {
+        return ProceededEvent.builder()
+                .eventId(eventId)
+                .build();
+    }
+
+
+    public ProceededEvent() {
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public ProceededEvent(Long eventId) {
+        this.eventId = eventId;
+    }
+}

--- a/prize/src/main/java/ddalkak/prize/eventhandler/eventlistener/KafkaConsumer.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/eventlistener/KafkaConsumer.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class KafkaEventListener {
+public class KafkaConsumer {
     private final EventHandler eventHandler;
 
     @KafkaListener(
@@ -24,4 +24,5 @@ public class KafkaEventListener {
           ack.acknowledge();
 
     }
+
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/impl/KafkaEventHandler.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/impl/KafkaEventHandler.java
@@ -1,5 +1,6 @@
 package ddalkak.prize.eventhandler.impl;
 
+import ddalkak.prize.aop.annotation.EnableIdempotent;
 import ddalkak.prize.config.error.exception.OutOfStockException;
 import ddalkak.prize.domain.entity.EventType;
 import ddalkak.prize.dto.event.DecreaseResultEvent;
@@ -9,7 +10,6 @@ import ddalkak.prize.eventhandler.EventHandler;
 import ddalkak.prize.eventhandler.eventpublisher.EventPublisher;
 import ddalkak.prize.service.outbox.OutBoxService;
 import ddalkak.prize.service.prize.PrizeService;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -33,6 +33,7 @@ public class KafkaEventHandler implements EventHandler {
      */
     @Override
     @Transactional
+    @EnableIdempotent(eventId = "#event.eventId()")
     public void handleDecreaseStockEvent(DrawWinEvent event) {
         log.info("Received event: eventId= {}, prizeId= {}", event.eventId(), event.prizeId());
         // 상품 재고 감소 처리
@@ -74,4 +75,5 @@ public class KafkaEventHandler implements EventHandler {
                     Instant.now()));
         }
     }
+
 }

--- a/prize/src/main/java/ddalkak/prize/repository/proceededEvent/ProceededEventRepository.java
+++ b/prize/src/main/java/ddalkak/prize/repository/proceededEvent/ProceededEventRepository.java
@@ -1,0 +1,11 @@
+package ddalkak.prize.repository.proceededEvent;
+
+import ddalkak.prize.domain.entity.ProceededEvent;
+
+import java.util.Optional;
+
+public interface ProceededEventRepository {
+    Optional<ProceededEvent> findByEventId(Long eventId);
+
+    ProceededEvent save(ProceededEvent proceededEvent);
+}

--- a/prize/src/main/java/ddalkak/prize/repository/proceededEvent/ProceededJpaRepository.java
+++ b/prize/src/main/java/ddalkak/prize/repository/proceededEvent/ProceededJpaRepository.java
@@ -1,0 +1,11 @@
+package ddalkak.prize.repository.proceededEvent;
+
+import ddalkak.prize.domain.entity.ProceededEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProceededJpaRepository extends JpaRepository<ProceededEvent, Long> {
+
+    Optional<ProceededEvent> findByEventId(Long eventId);
+}

--- a/prize/src/main/java/ddalkak/prize/repository/proceededEvent/impl/ProceededEventRepositoryImpl.java
+++ b/prize/src/main/java/ddalkak/prize/repository/proceededEvent/impl/ProceededEventRepositoryImpl.java
@@ -1,0 +1,26 @@
+package ddalkak.prize.repository.proceededEvent.impl;
+
+import ddalkak.prize.domain.entity.ProceededEvent;
+import ddalkak.prize.repository.proceededEvent.ProceededEventRepository;
+import ddalkak.prize.repository.proceededEvent.ProceededJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Repository
+public class ProceededEventRepositoryImpl implements ProceededEventRepository {
+    private final ProceededJpaRepository proceededJpaRepository;
+
+
+    @Override
+    public Optional<ProceededEvent> findByEventId(Long eventId) {
+       return proceededJpaRepository.findByEventId(eventId);
+    }
+
+    @Override
+    public ProceededEvent save(ProceededEvent proceededEvent) {
+       return proceededJpaRepository.save(proceededEvent);
+    }
+}

--- a/prize/src/main/java/ddalkak/prize/service/proceededEvent/ProceededEventService.java
+++ b/prize/src/main/java/ddalkak/prize/service/proceededEvent/ProceededEventService.java
@@ -1,0 +1,9 @@
+package ddalkak.prize.service.proceededEvent;
+
+
+
+public interface ProceededEventService {
+    boolean isProceededEvent(Long eventId);
+
+    void save(Long eventId);
+}

--- a/prize/src/main/java/ddalkak/prize/service/proceededEvent/impl/ProceededServiceImpl.java
+++ b/prize/src/main/java/ddalkak/prize/service/proceededEvent/impl/ProceededServiceImpl.java
@@ -1,0 +1,27 @@
+package ddalkak.prize.service.proceededEvent.impl;
+
+import ddalkak.prize.domain.entity.ProceededEvent;
+import ddalkak.prize.repository.proceededEvent.ProceededEventRepository;
+import ddalkak.prize.service.proceededEvent.ProceededEventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProceededServiceImpl implements ProceededEventService {
+
+    private final ProceededEventRepository proceededEventRepository;
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isProceededEvent(Long eventId) {
+        return proceededEventRepository.findByEventId(eventId)
+                .isPresent();
+    }
+    @Override
+    @Transactional
+    public void save(Long eventId) {
+        proceededEventRepository.save(ProceededEvent.from(eventId));
+    }
+
+}


### PR DESCRIPTION
- 이미 처리한 이벤트 정보를 관리하기 위한 RDB 테이블 추가
- 애노테이션 기반 AOP를 통해 적용, 이미 처리한 이벤트ID라면 early return, 신규 이벤트라면 비지니스 로직 처리 후 이벤트ID 저장
- 최종 offset commit은 반드시 DB 트랜잭션이 완료된 후 처리되어야 메세지 유실을 방지할 수 있음
- 최초 이벤트 수신부인 Consumer 클래스는 Handler에게 비지니스 로직을 위임, 비지니스 로직이 성공적으로 끝나면 ack 처리
- Handler에서 부모 트랜잭션을 시작, 도메인 관련 비지니스 로직 및 AOP를 통한 멱등성 관련 로직을 하나의 트랜잭션으로 묶어 처리
결론:
이미 처리한 이벤트ID -> 체크 후 early return
신규 이벤트ID -> 트랜잭션 성공 -> ack 시도(실패해도 처리한 이벤트ID가 기록되니 중복 처리 방지 가능)
신규 이벤트ID -> 트랜잭션 실패 -> ack 시도를 안함(재처리)