### PR TITLE
[상품] 처리에 실패한 이벤트 처리 기능

### DIFF
--- a/prize/src/main/java/ddalkak/prize/PrizeApplication.java
+++ b/prize/src/main/java/ddalkak/prize/PrizeApplication.java
@@ -2,7 +2,6 @@ package ddalkak.prize;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
 public class PrizeApplication {

--- a/prize/src/main/java/ddalkak/prize/config/RetryableExceptionConfig.java
+++ b/prize/src/main/java/ddalkak/prize/config/RetryableExceptionConfig.java
@@ -1,0 +1,32 @@
+package ddalkak.prize.config;
+
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.dao.TransientDataAccessException;
+
+import java.net.SocketTimeoutException;
+import java.util.List;
+
+@Configuration
+public class RetryableExceptionConfig {
+
+    @Bean
+    public List<Class<? extends Throwable>> retryableExceptions(){
+        return List.of(
+                SocketTimeoutException.class,
+                TransientDataAccessException.class,
+                RecoverableDataAccessException.class
+        );
+    }
+    @Bean
+    public List<Class<? extends Throwable>> nonRetryableExceptions(){
+        return List.of(
+                ConstraintViolationException.class,
+                DataIntegrityViolationException.class
+        );
+    }
+
+}

--- a/prize/src/main/java/ddalkak/prize/config/error/ErrorResponse.java
+++ b/prize/src/main/java/ddalkak/prize/config/error/ErrorResponse.java
@@ -1,8 +1,8 @@
 package ddalkak.prize.config.error;
 
 import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter

--- a/prize/src/main/java/ddalkak/prize/config/kafka/KafkaConstants.java
+++ b/prize/src/main/java/ddalkak/prize/config/kafka/KafkaConstants.java
@@ -1,0 +1,9 @@
+package ddalkak.prize.config.kafka;
+
+public final class KafkaConstants {
+    public static final int MAX_RETRY_ATTEMPTS = 4;
+    public static final int MAX_REDRIVE_COUNT = 4;
+    public static final String CAUSE_EXCEPTION = "kafka_exception-cause-fqcn";
+    public static final String REDRIVE_COUNT = "redrive-count";
+    public static final String ERROR_MESSAGE = "kafka_exception-message";
+}

--- a/prize/src/main/java/ddalkak/prize/config/kafka/KafkaConsumerConfig.java
+++ b/prize/src/main/java/ddalkak/prize/config/kafka/KafkaConsumerConfig.java
@@ -41,7 +41,6 @@ public class KafkaConsumerConfig {
     }
 
 
-
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, DrawWinEvent> kafkaListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, DrawWinEvent> factory =
@@ -50,5 +49,8 @@ public class KafkaConsumerConfig {
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
         return factory;
     }
+
+
+
 
 }

--- a/prize/src/main/java/ddalkak/prize/config/kafka/KafkaErrorHandleConfig.java
+++ b/prize/src/main/java/ddalkak/prize/config/kafka/KafkaErrorHandleConfig.java
@@ -1,0 +1,42 @@
+package ddalkak.prize.config.kafka;
+
+import ddalkak.prize.domain.entity.EventType;
+import ddalkak.prize.dto.event.DrawWinEvent;
+import ddalkak.prize.dto.event.ExternalEvent;
+import ddalkak.prize.eventhandler.DltHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafkaRetryTopic;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
+import org.springframework.kafka.support.EndpointHandlerMethod;
+
+import java.util.List;
+
+
+@Configuration
+@EnableKafkaRetryTopic
+@RequiredArgsConstructor
+public class KafkaErrorHandleConfig {
+    private final List<Class<? extends Throwable>> retryableExceptions;
+    private final ConcurrentKafkaListenerContainerFactory<String, DrawWinEvent> kafkaListenerContainerFactory;
+
+
+
+    @Bean
+    public RetryTopicConfiguration retryTopicConfig(KafkaTemplate<String, ExternalEvent> dltKafkaTemplate) throws NoSuchMethodException {
+        return RetryTopicConfigurationBuilder
+                .newInstance()
+                .maxAttempts(KafkaConstants.MAX_RETRY_ATTEMPTS)
+                .exponentialBackoff(500L,2.0,1000 * 60L )
+                .listenerFactory(kafkaListenerContainerFactory)
+                .includeTopic(EventType.DRAW_WIN.getTopic())
+                .dltHandlerMethod(new EndpointHandlerMethod(DltHandler.class, "handleDltEvents"))
+                .retryOn(retryableExceptions)
+                .create(dltKafkaTemplate);
+    }
+
+}

--- a/prize/src/main/java/ddalkak/prize/config/kafka/KafkaProducerConfig.java
+++ b/prize/src/main/java/ddalkak/prize/config/kafka/KafkaProducerConfig.java
@@ -1,6 +1,6 @@
 package ddalkak.prize.config.kafka;
 
-import ddalkak.prize.dto.event.DecreaseResultEvent;
+import ddalkak.prize.dto.event.ExternalEvent;
 import ddalkak.prize.eventhandler.eventpublisher.KafkaProducerListener;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -26,7 +26,7 @@ public class KafkaProducerConfig {
     private KafkaProducerListener kafkaProducerListener;
 
     @Bean
-    public ProducerFactory<String, DecreaseResultEvent> producerFactory() {
+    public ProducerFactory<String, ExternalEvent> producerFactory() {
         Map<String, Object> props = new HashMap<>();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -37,9 +37,17 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, DecreaseResultEvent> kafkaTemplate() {
-        KafkaTemplate<String, DecreaseResultEvent> template = new KafkaTemplate<>(producerFactory());
+    public KafkaTemplate<String, ExternalEvent> kafkaTemplate() {
+        KafkaTemplate<String, ExternalEvent> template = new KafkaTemplate<>(producerFactory());
         template.setProducerListener(kafkaProducerListener);
         return template;
     }
+
+    @Bean
+    public KafkaTemplate<String, ExternalEvent> dltKafkaTemplate() {
+        KafkaTemplate<String, ExternalEvent> template = new KafkaTemplate<>(producerFactory());
+        return template;
+    }
+
+
 }

--- a/prize/src/main/java/ddalkak/prize/controller/PrizeController.java
+++ b/prize/src/main/java/ddalkak/prize/controller/PrizeController.java
@@ -1,22 +1,17 @@
 package ddalkak.prize.controller;
 
 import ddalkak.prize.dto.request.PrizeSaveRequestDto;
-import ddalkak.prize.dto.response.AdminPrizeResponseDto;
 import ddalkak.prize.dto.request.PrizeUpdateRequestDto;
+import ddalkak.prize.dto.response.AdminPrizeResponseDto;
 import ddalkak.prize.dto.response.PageResponseDto;
-import ddalkak.prize.dto.response.PrizeResponseDto;
 import ddalkak.prize.service.prize.PrizeService;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.PositiveOrZero;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/prizes")

--- a/prize/src/main/java/ddalkak/prize/domain/entity/DiscardedEvent.java
+++ b/prize/src/main/java/ddalkak/prize/domain/entity/DiscardedEvent.java
@@ -1,0 +1,51 @@
+package ddalkak.prize.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class DiscardedEvent extends BaseEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column
+    private Long eventId;
+    @Enumerated(EnumType.STRING)
+    private EventType eventType;
+    @Column(columnDefinition = "JSON")
+    private String payload;
+    @Column
+    private String causeException;
+    @Lob
+    private String errorMessage;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private DiscardedEvent(Long eventId, Long id, EventType eventType, String payload, String causeException, String errorMessage) {
+        this.eventId = eventId;
+        this.id = id;
+        this.eventType = eventType;
+        this.payload = payload;
+        this.causeException = causeException;
+        this.errorMessage = errorMessage;
+    }
+
+    public DiscardedEvent() {
+
+    }
+
+    public static DiscardedEvent of(EventType eventType ,Long eventId,String payload ,String causeException, String errorMessage) {
+        return DiscardedEvent.builder()
+                .eventType(eventType)
+                .eventId(eventId)
+                .payload(payload)
+                .causeException(causeException)
+                .errorMessage(errorMessage)
+                .build();
+    }
+
+
+
+
+}

--- a/prize/src/main/java/ddalkak/prize/domain/entity/EventType.java
+++ b/prize/src/main/java/ddalkak/prize/domain/entity/EventType.java
@@ -1,6 +1,15 @@
 package ddalkak.prize.domain.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum EventType {
-    DRAW_WIN,
-    DECREASE_RESULT,
+    DRAW_WIN("draw.win"),
+    DECREASE_RESULT("prize.decrease-result");
+
+    EventType(String topic) {
+        this.topic = topic;
+    }
+
+    private String topic;
 }

--- a/prize/src/main/java/ddalkak/prize/domain/entity/PrizeOutbox.java
+++ b/prize/src/main/java/ddalkak/prize/domain/entity/PrizeOutbox.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Entity
 @Getter
 public class PrizeOutbox extends BaseEntity {
-    @Id@GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Column(nullable = false)
     private Long eventId;

--- a/prize/src/main/java/ddalkak/prize/dto/event/DrawWinEvent.java
+++ b/prize/src/main/java/ddalkak/prize/dto/event/DrawWinEvent.java
@@ -7,5 +7,7 @@ public record DrawWinEvent(
         Long prizeId,
         Long drawId,
         Instant occurAt
+
 ) implements ExternalEvent {
+
 }

--- a/prize/src/main/java/ddalkak/prize/dto/event/ExternalEvent.java
+++ b/prize/src/main/java/ddalkak/prize/dto/event/ExternalEvent.java
@@ -6,4 +6,5 @@ public interface ExternalEvent {
     Long eventId();
     Instant occurAt();
 
+
 }

--- a/prize/src/main/java/ddalkak/prize/dto/request/PrizeSaveRequestDto.java
+++ b/prize/src/main/java/ddalkak/prize/dto/request/PrizeSaveRequestDto.java
@@ -1,8 +1,6 @@
 package ddalkak.prize.dto.request;
 
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Lob;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;

--- a/prize/src/main/java/ddalkak/prize/dto/response/PageResponseDto.java
+++ b/prize/src/main/java/ddalkak/prize/dto/response/PageResponseDto.java
@@ -2,6 +2,7 @@ package ddalkak.prize.dto.response;
 
 import lombok.AccessLevel;
 import lombok.Builder;
+
 import java.util.List;
 
 @Builder(access = AccessLevel.PRIVATE)

--- a/prize/src/main/java/ddalkak/prize/eventhandler/DecreaseResult.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/DecreaseResult.java
@@ -2,5 +2,5 @@ package ddalkak.prize.eventhandler;
 
 public enum DecreaseResult {
     SUCCESS,
-    FAILURE;
+    FAILURE
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/DltHandler.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/DltHandler.java
@@ -1,0 +1,71 @@
+package ddalkak.prize.eventhandler;
+
+import ddalkak.prize.config.kafka.KafkaConstants;
+import ddalkak.prize.domain.entity.EventType;
+import ddalkak.prize.dto.event.DrawWinEvent;
+import ddalkak.prize.dto.event.ExternalEvent;
+import ddalkak.prize.eventhandler.eventpublisher.EventPublisher;
+import ddalkak.prize.service.discardedEvent.DiscardedEventService;
+import ddalkak.prize.service.util.HeaderUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class DltHandler {
+    private final List<Class<? extends Throwable>> retryableExceptions;
+    private final EventPublisher eventPublisher;
+    private final DiscardedEventService discardedEventService;
+
+
+    public void handleDltEvents(DrawWinEvent event,
+                                Acknowledgment ack,
+                                @Header(value = KafkaConstants.REDRIVE_COUNT, required = false) byte[] redriveRaw,
+                                @Header(value = KafkaConstants.ERROR_MESSAGE, required = false) String errMsg,
+                                @Header(KafkaConstants.CAUSE_EXCEPTION) String exception) throws ClassNotFoundException {
+        int redriveAttempts = HeaderUtils.toInteger(redriveRaw);
+
+
+        log.info("rederiveAttempts ={}", redriveAttempts);
+        if (isUnderMaxAttempt(redriveAttempts) && isRetryableEx(exception)) {
+            RecordHeader newHeader = new RecordHeader(KafkaConstants.REDRIVE_COUNT, HeaderUtils.toByteArray(redriveAttempts + 1));
+
+
+            ProducerRecord<String, ExternalEvent> producerRecord = new ProducerRecord<>(EventType.DRAW_WIN.getTopic(), event);
+            producerRecord.headers().add(newHeader);
+
+            eventPublisher.publish(producerRecord, ack);
+            return;
+
+        }
+        if (isRetryableEx(exception)) {
+            log.info("MAX_REDRIVE_COUNT 초과");
+        } else {
+            log.info("non retryable ex");
+        }
+        discardedEventService.save(EventType.DRAW_WIN ,event, exception, errMsg);
+        ack.acknowledge();
+    }
+
+    private static boolean isUnderMaxAttempt(int redriveAttempts) {
+        return redriveAttempts <= KafkaConstants.MAX_REDRIVE_COUNT;
+    }
+
+    private boolean isRetryableEx(String exception) throws ClassNotFoundException {
+        Class<?> exceptionClass = Class.forName(exception);
+        // 포함 여부 확인 (isAssignableFrom 사용 가능)
+        boolean isRetryableEx = retryableExceptions.stream()
+                .anyMatch(clazz -> clazz.isAssignableFrom(exceptionClass));
+        return isRetryableEx;
+    }
+
+
+}

--- a/prize/src/main/java/ddalkak/prize/eventhandler/eventlistener/KafkaConsumer.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/eventlistener/KafkaConsumer.java
@@ -2,14 +2,15 @@ package ddalkak.prize.eventhandler.eventlistener;
 
 import ddalkak.prize.dto.event.DrawWinEvent;
 import ddalkak.prize.eventhandler.EventHandler;
-
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class KafkaConsumer {
     private final EventHandler eventHandler;
 
@@ -22,7 +23,6 @@ public class KafkaConsumer {
     public void onMessage(DrawWinEvent event, Acknowledgment ack) {
           eventHandler.handleDecreaseStockEvent(event);
           ack.acknowledge();
-
     }
 
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/eventpublisher/EventPublisher.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/eventpublisher/EventPublisher.java
@@ -1,7 +1,10 @@
 package ddalkak.prize.eventhandler.eventpublisher;
 
-import ddalkak.prize.dto.event.DecreaseResultEvent;
+import ddalkak.prize.dto.event.ExternalEvent;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.kafka.support.Acknowledgment;
 
 public interface EventPublisher {
-    void publish(DecreaseResultEvent event);
+    void publish(String topic,ExternalEvent event);
+    void publish(ProducerRecord<String,ExternalEvent> record, Acknowledgment ack);
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/eventpublisher/KafkaProducerListener.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/eventpublisher/KafkaProducerListener.java
@@ -1,6 +1,7 @@
 package ddalkak.prize.eventhandler.eventpublisher;
 
 import ddalkak.prize.dto.event.DecreaseResultEvent;
+import ddalkak.prize.dto.event.ExternalEvent;
 import ddalkak.prize.service.outbox.OutBoxService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,12 +13,11 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class KafkaProducerListener implements ProducerListener<String, DecreaseResultEvent> {
+public class KafkaProducerListener implements ProducerListener<String, ExternalEvent> {
     private final OutBoxService outBoxService;
     @Override
-    public void onSuccess(ProducerRecord<String, DecreaseResultEvent> producerRecord, RecordMetadata recordMetadata) {
-        DecreaseResultEvent event = producerRecord.value();
-        log.info("Event published successfully: eventId= {}, prizeId= {}, result= {}", event.eventId(), event.prizeId(), event.result());
+    public void onSuccess(ProducerRecord<String, ExternalEvent> producerRecord, RecordMetadata recordMetadata) {
+        DecreaseResultEvent event = (DecreaseResultEvent) producerRecord.value();
         if (event instanceof DecreaseResultEvent ) {
             outBoxService.markEventAsPublished(event.eventId());
         }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/eventpublisher/impl/KafkaPublisher.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/eventpublisher/impl/KafkaPublisher.java
@@ -1,17 +1,32 @@
 package ddalkak.prize.eventhandler.eventpublisher.impl;
 
-import ddalkak.prize.dto.event.DecreaseResultEvent;
+import ddalkak.prize.dto.event.ExternalEvent;
 import ddalkak.prize.eventhandler.eventpublisher.EventPublisher;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KafkaPublisher implements EventPublisher {
-    private final KafkaTemplate<String, DecreaseResultEvent> kafkaTemplate;
+    private final KafkaTemplate<String, ExternalEvent> kafkaTemplate;
+    private final KafkaTemplate<String, ExternalEvent> dltKafkaTemplate;
     @Override
-    public void publish(DecreaseResultEvent event) {
-        kafkaTemplate.send("prize.decrease-result",event);
+    public void publish(String topic,ExternalEvent event) {
+        kafkaTemplate.send(topic,event);
+    }
+    @Override
+    public void publish(ProducerRecord<String,ExternalEvent> record, Acknowledgment ack) {
+        dltKafkaTemplate.send(record).whenComplete((sendResult, ex) -> {
+            if (ex == null) {
+                ack.acknowledge();
+            } else {
+                log.info("dlt -> 원본 토픽으로 카프카 발행 실패");
+            }
+        });
     }
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/impl/KafkaEventHandler.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/impl/KafkaEventHandler.java
@@ -48,7 +48,7 @@ public class KafkaEventHandler implements EventHandler {
                     Instant.now()
             );
             outBoxService.save(decreaseResultEvent, EventType.DECREASE_RESULT);
-            eventPublisher.publish(new DecreaseResultEvent(
+            eventPublisher.publish(EventType.DECREASE_RESULT.getTopic(),new DecreaseResultEvent(
                     event.eventId(),
                     event.prizeId(),
                     event.drawId(),
@@ -67,7 +67,7 @@ public class KafkaEventHandler implements EventHandler {
             );
 
             outBoxService.save(decreaseResultEvent, EventType.DECREASE_RESULT);
-            eventPublisher.publish(new DecreaseResultEvent(
+            eventPublisher.publish(EventType.DECREASE_RESULT.getTopic(),new DecreaseResultEvent(
                     event.eventId(),
                     event.prizeId(),
                     event.drawId(),

--- a/prize/src/main/java/ddalkak/prize/repository/discardedEvent/DiscardedEventJpaRepository.java
+++ b/prize/src/main/java/ddalkak/prize/repository/discardedEvent/DiscardedEventJpaRepository.java
@@ -1,0 +1,7 @@
+package ddalkak.prize.repository.discardedEvent;
+
+import ddalkak.prize.domain.entity.DiscardedEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiscardedEventJpaRepository extends JpaRepository<DiscardedEvent, Long> {
+}

--- a/prize/src/main/java/ddalkak/prize/repository/discardedEvent/DiscardedEventRepository.java
+++ b/prize/src/main/java/ddalkak/prize/repository/discardedEvent/DiscardedEventRepository.java
@@ -1,0 +1,7 @@
+package ddalkak.prize.repository.discardedEvent;
+
+import ddalkak.prize.domain.entity.DiscardedEvent;
+
+public interface DiscardedEventRepository {
+    void save(DiscardedEvent discardedEvent);
+}

--- a/prize/src/main/java/ddalkak/prize/repository/discardedEvent/impl/DiscardedEventRepositoryImpl.java
+++ b/prize/src/main/java/ddalkak/prize/repository/discardedEvent/impl/DiscardedEventRepositoryImpl.java
@@ -1,0 +1,18 @@
+package ddalkak.prize.repository.discardedEvent.impl;
+
+import ddalkak.prize.domain.entity.DiscardedEvent;
+import ddalkak.prize.repository.discardedEvent.DiscardedEventJpaRepository;
+import ddalkak.prize.repository.discardedEvent.DiscardedEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DiscardedEventRepositoryImpl implements DiscardedEventRepository {
+    private final DiscardedEventJpaRepository discardedEventJpaRepository;
+
+    @Override
+    public void save(DiscardedEvent discardedEvent) {
+        discardedEventJpaRepository.save(discardedEvent);
+    }
+}

--- a/prize/src/main/java/ddalkak/prize/service/discardedEvent/DiscardedEventService.java
+++ b/prize/src/main/java/ddalkak/prize/service/discardedEvent/DiscardedEventService.java
@@ -1,0 +1,8 @@
+package ddalkak.prize.service.discardedEvent;
+
+import ddalkak.prize.domain.entity.EventType;
+import ddalkak.prize.dto.event.ExternalEvent;
+
+public interface DiscardedEventService {
+    void save(EventType eventType , ExternalEvent event, String exception, String errMsg);
+}

--- a/prize/src/main/java/ddalkak/prize/service/discardedEvent/impl/DiscardedEventServiceImpl.java
+++ b/prize/src/main/java/ddalkak/prize/service/discardedEvent/impl/DiscardedEventServiceImpl.java
@@ -1,0 +1,48 @@
+package ddalkak.prize.service.discardedEvent.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ddalkak.prize.aop.annotation.EnableIdempotent;
+import ddalkak.prize.domain.entity.DiscardedEvent;
+import ddalkak.prize.domain.entity.EventType;
+import ddalkak.prize.dto.event.ExternalEvent;
+import ddalkak.prize.repository.discardedEvent.DiscardedEventRepository;
+import ddalkak.prize.service.discardedEvent.DiscardedEventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DiscardedEventServiceImpl implements DiscardedEventService {
+    private final DiscardedEventRepository discardedEventRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @Transactional
+    @EnableIdempotent(eventId = "#event.eventId()")
+    public void save(EventType eventType, ExternalEvent event, String exception, String errMsg) {
+
+        discardedEventRepository.save(
+                DiscardedEvent.of(
+                        eventType,
+                        event.eventId(),
+                        serialize(event),
+                        exception,
+                        errMsg
+                )
+        );
+
+    }
+
+    private String serialize(ExternalEvent event) {
+        String payload = null;
+        try {
+            payload = objectMapper.writeValueAsString(event);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Error while converting event to JSON");
+        }
+        return payload;
+    }
+
+
+}

--- a/prize/src/main/java/ddalkak/prize/service/outbox/OutBoxService.java
+++ b/prize/src/main/java/ddalkak/prize/service/outbox/OutBoxService.java
@@ -2,9 +2,7 @@ package ddalkak.prize.service.outbox;
 
 import ddalkak.prize.domain.entity.EventType;
 import ddalkak.prize.dto.event.DecreaseResultEvent;
-import ddalkak.prize.dto.event.DrawWinEvent;
 import ddalkak.prize.dto.event.ExternalEvent;
-import ddalkak.prize.eventhandler.DecreaseResult;
 
 import java.util.List;
 

--- a/prize/src/main/java/ddalkak/prize/service/outbox/OutboxScheduler.java
+++ b/prize/src/main/java/ddalkak/prize/service/outbox/OutboxScheduler.java
@@ -1,5 +1,6 @@
 package ddalkak.prize.service.outbox;
 
+import ddalkak.prize.domain.entity.EventType;
 import ddalkak.prize.dto.event.DecreaseResultEvent;
 import ddalkak.prize.eventhandler.eventpublisher.EventPublisher;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +40,7 @@ public class OutboxScheduler implements SchedulingConfigurer {
         if (!events.isEmpty()) {
             interval.set(INITIAL);
             for (DecreaseResultEvent event : events) {
-                eventPublisher.publish(event);
+                eventPublisher.publish(EventType.DECREASE_RESULT.getTopic(),event);
             }
         } else {
             interval.updateAndGet(lastInterval -> Math.min(MAX_BACKOFF, lastInterval * MULTIPLIER));

--- a/prize/src/main/java/ddalkak/prize/service/outbox/impl/OutboxServiceImpl.java
+++ b/prize/src/main/java/ddalkak/prize/service/outbox/impl/OutboxServiceImpl.java
@@ -8,7 +8,6 @@ import ddalkak.prize.dto.event.DecreaseResultEvent;
 import ddalkak.prize.dto.event.ExternalEvent;
 import ddalkak.prize.repository.outbox.OutboxRepository;
 import ddalkak.prize.service.outbox.OutBoxService;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,7 +28,7 @@ public class OutboxServiceImpl implements OutBoxService {
 
         String payload = serialize(event);
         PrizeOutbox prizeOutbox = new PrizeOutbox(event.eventId(), payload, eventType);
-        log.info("Saving event to outbox: {}" , prizeOutbox.toString());
+        log.info("Saving event to outbox: {}" , prizeOutbox);
         PrizeOutbox savedPrizeOutbox = outboxRepository.save(new PrizeOutbox(event.eventId(), payload, eventType));
 
         return savedPrizeOutbox.getId();

--- a/prize/src/main/java/ddalkak/prize/service/prize/PrizeService.java
+++ b/prize/src/main/java/ddalkak/prize/service/prize/PrizeService.java
@@ -1,12 +1,10 @@
 package ddalkak.prize.service.prize;
 
 
-import ddalkak.prize.dto.response.AdminPrizeResponseDto;
 import ddalkak.prize.dto.request.PrizeSaveRequestDto;
 import ddalkak.prize.dto.request.PrizeUpdateRequestDto;
+import ddalkak.prize.dto.response.AdminPrizeResponseDto;
 import ddalkak.prize.dto.response.PageResponseDto;
-import ddalkak.prize.dto.response.PrizeResponseDto;
-import org.springframework.data.domain.Page;
 
 public interface PrizeService {
     Long save(PrizeSaveRequestDto prizeSaveRequestDto);

--- a/prize/src/main/java/ddalkak/prize/service/prize/impl/PrizeServiceImpl.java
+++ b/prize/src/main/java/ddalkak/prize/service/prize/impl/PrizeServiceImpl.java
@@ -13,14 +13,12 @@ import ddalkak.prize.repository.prize.PrizeRepository;
 import ddalkak.prize.service.prize.PrizeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 

--- a/prize/src/main/java/ddalkak/prize/service/util/HeaderUtils.java
+++ b/prize/src/main/java/ddalkak/prize/service/util/HeaderUtils.java
@@ -1,0 +1,16 @@
+package ddalkak.prize.service.util;
+
+import java.nio.ByteBuffer;
+
+public class HeaderUtils {
+    public static int toInteger(byte[] origin) {
+        if(origin == null) {
+            return 1;
+        }
+        return ByteBuffer.wrap(origin).getInt();
+    }
+
+    public static byte[] toByteArray(int origin) {
+        return ByteBuffer.allocate(4).putInt(origin).array();
+    }
+}


### PR DESCRIPTION
- 기본적으로 실패한 카프카 이벤트들을 지수적 백오프로 일정 횟수 재시도
- 재시도 했음에도 실패한 이벤트들은 dlt로 이동 -> DltHander 클래스에서 처리
- DltHandler.java: 재시도 후에도 실패하여 dlt에 들어온 메시지들을 회복 가능성이있는 예외인지 아닌지 분류하여 다시 재시도를 위해 원본 토픽으로 발행 , 일정 횟수 이상 재시도 하였음에도 실패한 이벤트들은 예외 정보와 이벤트정보를 db에 저장