### PR TITLE
[응모 서비스] 비정상 이벤트 핸들링

### DIFF
--- a/draw/src/main/java/ddalkak/draw/common/config/KafkaErrorHandleConfig.java
+++ b/draw/src/main/java/ddalkak/draw/common/config/KafkaErrorHandleConfig.java
@@ -1,0 +1,69 @@
+package ddalkak.draw.common.config;
+
+import ddalkak.draw.domain.EventType;
+import ddalkak.draw.domain.KafkaConstants;
+import ddalkak.draw.dto.event.DecreaseStockEvent;
+import ddalkak.draw.dto.event.ExternalEvent;
+import ddalkak.draw.dto.event.LoginEvent;
+import ddalkak.draw.dto.event.SignUpEvent;
+import ddalkak.draw.service.event.DltHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafkaRetryTopic;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
+import org.springframework.kafka.support.EndpointHandlerMethod;
+
+import java.util.List;
+
+@Configuration
+@EnableKafkaRetryTopic
+@RequiredArgsConstructor
+public class KafkaErrorHandleConfig {
+    private final List<Class<? extends Throwable>> retryableExceptions;
+    private final ConcurrentKafkaListenerContainerFactory<String, SignUpEvent> kafkaSignUpListenerContainerFactory;
+    private final ConcurrentKafkaListenerContainerFactory<String, LoginEvent> kafkaLoginListenerContainerFactory;
+    private final ConcurrentKafkaListenerContainerFactory<String, DecreaseStockEvent> kafkaDecreaseResultListenerContainerFactory;
+
+    @Bean
+    public RetryTopicConfiguration retrySignupTopic(KafkaTemplate<String, ExternalEvent> dltKafkaTemplate) {
+        return RetryTopicConfigurationBuilder
+                .newInstance()
+                .maxAttempts(KafkaConstants.MAX_RETRY_ATTEMPTS)
+                .exponentialBackoff(500L, 2.0, 60_000L)
+                .listenerFactory(kafkaSignUpListenerContainerFactory)
+                .includeTopic(EventType.SIGNUP.getTopic())
+                .dltHandlerMethod(new EndpointHandlerMethod(DltHandler.class, "handleSignupDltEvent"))
+                .retryOn(retryableExceptions)
+                .create(dltKafkaTemplate);
+    }
+
+    @Bean
+    public RetryTopicConfiguration retryLoginTopic(KafkaTemplate<String, ExternalEvent> dltKafkaTemplate) {
+        return RetryTopicConfigurationBuilder
+                .newInstance()
+                .maxAttempts(KafkaConstants.MAX_RETRY_ATTEMPTS)
+                .exponentialBackoff(500L, 2.0, 60_000L)
+                .listenerFactory(kafkaLoginListenerContainerFactory)
+                .includeTopic(EventType.LOGIN.getTopic())
+                .dltHandlerMethod(new EndpointHandlerMethod(DltHandler.class, "handleLoginDltEvent"))
+                .retryOn(retryableExceptions)
+                .create(dltKafkaTemplate);
+    }
+
+    @Bean
+    public RetryTopicConfiguration retryDecreaseStockTopic(KafkaTemplate<String, ExternalEvent> dltKafkaTemplate) {
+        return RetryTopicConfigurationBuilder
+                .newInstance()
+                .maxAttempts(KafkaConstants.MAX_RETRY_ATTEMPTS)
+                .exponentialBackoff(500L, 2.0, 60_000L)
+                .listenerFactory(kafkaDecreaseResultListenerContainerFactory)
+                .includeTopic(EventType.DECREASE_STOCK.getTopic())
+                .dltHandlerMethod(new EndpointHandlerMethod(DltHandler.class, "handleDecreaseStockDltEvent"))
+                .retryOn(retryableExceptions)
+                .create(dltKafkaTemplate);
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/common/config/KafkaProducerConfig.java
+++ b/draw/src/main/java/ddalkak/draw/common/config/KafkaProducerConfig.java
@@ -39,4 +39,10 @@ public class KafkaProducerConfig {
         kafkaTemplate.setProducerListener(kafkaProducerListener);
         return kafkaTemplate;
     }
+
+    @Bean
+    public KafkaTemplate<String, ExternalEvent> dltKafkaTemplate() {
+        KafkaTemplate<String, ExternalEvent> kafkaTemplate = new KafkaTemplate<>(producerFactory());
+        return kafkaTemplate;
+    }
 }

--- a/draw/src/main/java/ddalkak/draw/common/config/RetryableExceptionConfig.java
+++ b/draw/src/main/java/ddalkak/draw/common/config/RetryableExceptionConfig.java
@@ -1,0 +1,25 @@
+package ddalkak.draw.common.config;
+
+import io.netty.channel.ConnectTimeoutException;
+import io.netty.handler.timeout.ReadTimeoutException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.dao.TransientDataAccessException;
+
+import java.net.SocketTimeoutException;
+import java.util.List;
+
+@Configuration
+public class RetryableExceptionConfig {
+    @Bean
+    public List<Class<? extends Throwable>> retryableExceptions() {
+        return List.of(
+                SocketTimeoutException.class,
+                ConnectTimeoutException.class,
+                ReadTimeoutException.class,
+                TransientDataAccessException.class,
+                RecoverableDataAccessException.class
+        );
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/domain/EventType.java
+++ b/draw/src/main/java/ddalkak/draw/domain/EventType.java
@@ -1,14 +1,16 @@
 package ddalkak.draw.domain;
 
-import ddalkak.draw.dto.event.DrawWinEvent;
-import ddalkak.draw.dto.event.ExternalEvent;
+import ddalkak.draw.dto.event.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
 public enum EventType {
-    DRAW_WIN(DrawWinEvent.class, "draw.win");
+    DRAW_WIN(DrawWinEvent.class, "draw.win"),
+    SIGNUP(SignUpEvent.class, "member.signup"),
+    LOGIN(LoginEvent.class, "member.login"),
+    DECREASE_STOCK(DecreaseStockEvent.class, "prize.decrease-result");
 
     private final Class<? extends ExternalEvent> targetClass;
     private final String topic;

--- a/draw/src/main/java/ddalkak/draw/domain/KafkaConstants.java
+++ b/draw/src/main/java/ddalkak/draw/domain/KafkaConstants.java
@@ -1,0 +1,9 @@
+package ddalkak.draw.domain;
+
+public final class KafkaConstants {
+    public static final int MAX_RETRY_ATTEMPTS = 4;
+    public static final int MAX_REDRIVE_COUNT = 4;
+    public static final String REDRIVE_COUNT = "redrive-count";
+    public static final String CAUSE_EXCEPTION = "kafka_exception-cause-fqcn";
+    public static final String ERROR_MESSAGE = "kafka_exception-message";
+}

--- a/draw/src/main/java/ddalkak/draw/domain/entity/DiscardedEvent.java
+++ b/draw/src/main/java/ddalkak/draw/domain/entity/DiscardedEvent.java
@@ -1,0 +1,43 @@
+package ddalkak.draw.domain.entity;
+
+import ddalkak.draw.domain.EventType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Entity
+public class DiscardedEvent extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long eventId;
+    @Enumerated(EnumType.STRING)
+    private EventType eventType;
+    @Column(columnDefinition = "JSON")
+    private String payload;
+    private String causeException;
+    @Lob
+    private String errorMessage;
+
+    public DiscardedEvent() {
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private DiscardedEvent(Long eventId, EventType eventType, String payload, String causeException, String errorMessage) {
+        this.eventId = eventId;
+        this.eventType = eventType;
+        this.payload = payload;
+        this.causeException = causeException;
+        this.errorMessage = errorMessage;
+    }
+
+    public static DiscardedEvent of(Long eventId, EventType eventType, String payload, String causeException, String errorMessage) {
+        return DiscardedEvent.builder()
+                .eventId(eventId)
+                .eventType(eventType)
+                .payload(payload)
+                .causeException(causeException)
+                .errorMessage(errorMessage)
+                .build();
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/dto/event/DecreaseStockEvent.java
+++ b/draw/src/main/java/ddalkak/draw/dto/event/DecreaseStockEvent.java
@@ -1,7 +1,10 @@
 package ddalkak.draw.dto.event;
 
+import java.time.Instant;
+
 public record DecreaseStockEvent(long eventId,
+                                 Instant occurAt,
                                  long drawId,
                                  long prizeId,
-                                 DecreaseResult result) {
+                                 DecreaseResult result) implements ExternalEvent {
 }

--- a/draw/src/main/java/ddalkak/draw/dto/event/LoginEvent.java
+++ b/draw/src/main/java/ddalkak/draw/dto/event/LoginEvent.java
@@ -2,7 +2,7 @@ package ddalkak.draw.dto.event;
 
 import java.time.Instant;
 
-public record LoginEvent(Long eventId,
+public record LoginEvent(long eventId,
                          Long memberId,
-                         Instant occurAt) {
+                         Instant occurAt) implements ExternalEvent{
 }

--- a/draw/src/main/java/ddalkak/draw/dto/event/SignUpEvent.java
+++ b/draw/src/main/java/ddalkak/draw/dto/event/SignUpEvent.java
@@ -4,5 +4,5 @@ import java.time.Instant;
 
 public record SignUpEvent(long eventId,
                           long memberId,
-                          Instant occurAt) {
+                          Instant occurAt) implements ExternalEvent {
 }

--- a/draw/src/main/java/ddalkak/draw/repository/discardedEvent/DiscardedEventRepository.java
+++ b/draw/src/main/java/ddalkak/draw/repository/discardedEvent/DiscardedEventRepository.java
@@ -1,0 +1,7 @@
+package ddalkak.draw.repository.discardedEvent;
+
+import ddalkak.draw.domain.entity.DiscardedEvent;
+
+public interface DiscardedEventRepository {
+    DiscardedEvent save(DiscardedEvent event);
+}

--- a/draw/src/main/java/ddalkak/draw/repository/discardedEvent/JpaDiscardedEventRepository.java
+++ b/draw/src/main/java/ddalkak/draw/repository/discardedEvent/JpaDiscardedEventRepository.java
@@ -1,0 +1,7 @@
+package ddalkak.draw.repository.discardedEvent;
+
+import ddalkak.draw.domain.entity.DiscardedEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaDiscardedEventRepository extends JpaRepository<DiscardedEvent, Long>, DiscardedEventRepository {
+}

--- a/draw/src/main/java/ddalkak/draw/service/discardedEvent/DiscardedEventService.java
+++ b/draw/src/main/java/ddalkak/draw/service/discardedEvent/DiscardedEventService.java
@@ -1,0 +1,43 @@
+package ddalkak.draw.service.discardedEvent;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ddalkak.draw.common.aop.annotation.EnableIdempotent;
+import ddalkak.draw.domain.EventType;
+import ddalkak.draw.domain.entity.DiscardedEvent;
+import ddalkak.draw.dto.event.ExternalEvent;
+import ddalkak.draw.repository.discardedEvent.DiscardedEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DiscardedEventService {
+    private final DiscardedEventRepository discardedEventRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    @EnableIdempotent(eventId = "#event.eventId()")
+    public void save(ExternalEvent event, EventType eventType, String causeException, String errorMessage) {
+        String payload = serializeEvent(event);
+        discardedEventRepository.save(
+                DiscardedEvent.of(event.eventId(),
+                        eventType,
+                        payload,
+                        causeException,
+                        errorMessage)
+        );
+    }
+
+    private String serializeEvent(ExternalEvent event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (JsonProcessingException e) {
+            log.warn("[DiscardedEventService.serializeEvent] objectMapper 직렬화 실패");
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/service/event/DltHandler.java
+++ b/draw/src/main/java/ddalkak/draw/service/event/DltHandler.java
@@ -1,0 +1,99 @@
+package ddalkak.draw.service.event;
+
+import ddalkak.draw.domain.EventType;
+import ddalkak.draw.domain.KafkaConstants;
+import ddalkak.draw.dto.event.DecreaseStockEvent;
+import ddalkak.draw.dto.event.ExternalEvent;
+import ddalkak.draw.dto.event.LoginEvent;
+import ddalkak.draw.dto.event.SignUpEvent;
+import ddalkak.draw.service.discardedEvent.DiscardedEventService;
+import ddalkak.draw.service.util.HeaderUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DltHandler {
+    private final List<Class<? extends Throwable>> retryableExceptions;
+    private final KafkaProducer kafkaProducer;
+    private final DiscardedEventService discardedEventService;
+
+    public void handleSignupDltEvent(SignUpEvent event,
+                                     Acknowledgment ack,
+                                     @Header(value = KafkaConstants.REDRIVE_COUNT, required = false) byte[] redriveCountRaw,
+                                     @Header(KafkaConstants.ERROR_MESSAGE) String errorMessage,
+                                     @Header(KafkaConstants.CAUSE_EXCEPTION) String exception) throws ClassNotFoundException {
+        int redriveCount = HeaderUtils.toInteger(redriveCountRaw);
+        if (isRetryableException(exception) && isUnderOfMaxAttempts(redriveCount)) {
+            kafkaProducer.publishWithAck(generateProducerRecordWithRedriveCount(event, EventType.SIGNUP, redriveCount), ack);
+            return;
+        }
+        logNonRetryableExInfo(exception);
+        discardedEventService.save(event, EventType.SIGNUP, exception, errorMessage);
+        ack.acknowledge();
+    }
+
+    public void handleLoginDltEvent(LoginEvent event,
+                                    Acknowledgment ack,
+                                    @Header(value = KafkaConstants.REDRIVE_COUNT, required = false) byte[] redriveCountRaw,
+                                    @Header(KafkaConstants.ERROR_MESSAGE) String errorMessage,
+                                    @Header(KafkaConstants.CAUSE_EXCEPTION) String exception) throws ClassNotFoundException {
+        int redriveCount = HeaderUtils.toInteger(redriveCountRaw);
+        if (isRetryableException(exception) && isUnderOfMaxAttempts(redriveCount)) {
+            kafkaProducer.publishWithAck(generateProducerRecordWithRedriveCount(event, EventType.LOGIN, redriveCount), ack);
+            return;
+        }
+        logNonRetryableExInfo(exception);
+        discardedEventService.save(event, EventType.LOGIN, exception, errorMessage);
+        ack.acknowledge();
+    }
+
+    public void handleDecreaseStockDltEvent(DecreaseStockEvent event,
+                                            Acknowledgment ack,
+                                            @Header(value = KafkaConstants.REDRIVE_COUNT, required = false) byte[] redriveCountRaw,
+                                            @Header(KafkaConstants.ERROR_MESSAGE) String errorMessage,
+                                            @Header(KafkaConstants.CAUSE_EXCEPTION) String exception) throws ClassNotFoundException {
+        int redriveCount = HeaderUtils.toInteger(redriveCountRaw);
+        if (isRetryableException(exception) && isUnderOfMaxAttempts(redriveCount)) {
+            kafkaProducer.publishWithAck(generateProducerRecordWithRedriveCount(event, EventType.DECREASE_STOCK, redriveCount), ack);
+            return;
+        }
+        logNonRetryableExInfo(exception);
+        discardedEventService.save(event, EventType.DECREASE_STOCK, exception, errorMessage);
+        ack.acknowledge();
+    }
+
+    private void logNonRetryableExInfo(String exception) throws ClassNotFoundException {
+        if (isRetryableException(exception)) {
+            log.info("Max Redrive Count 초과");
+        } else {
+            log.info("Non-Retryable Exception into Dlt");
+        }
+    }
+
+    private ProducerRecord<String, ExternalEvent> generateProducerRecordWithRedriveCount(ExternalEvent event, EventType eventType, int redriveCount) {
+        ProducerRecord<String, ExternalEvent> producerRecord = new ProducerRecord<>(eventType.getTopic(), event);
+        RecordHeader newHeader = new RecordHeader(KafkaConstants.REDRIVE_COUNT, HeaderUtils.toByteArray(redriveCount + 1));
+        producerRecord.headers().add(newHeader);
+        return producerRecord;
+    }
+
+    private boolean isUnderOfMaxAttempts(int redriveCount) {
+        return redriveCount <= KafkaConstants.MAX_REDRIVE_COUNT;
+    }
+
+    private boolean isRetryableException(String exception) throws ClassNotFoundException {
+        Class<?> exClass = Class.forName(exception);
+        boolean isRetryableEx = retryableExceptions.stream()
+                .anyMatch(clazz -> clazz.isAssignableFrom(exClass));
+        return isRetryableEx;
+    }
+}

--- a/draw/src/main/java/ddalkak/draw/service/event/KafkaProducer.java
+++ b/draw/src/main/java/ddalkak/draw/service/event/KafkaProducer.java
@@ -2,16 +2,31 @@ package ddalkak.draw.service.event;
 
 import ddalkak.draw.dto.event.ExternalEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class KafkaProducer implements ExternalEventPublisher {
     private final KafkaTemplate<String, ExternalEvent> kafkaTemplate;
+    private final KafkaTemplate<String, ExternalEvent> dltKafkaTemplate;
 
     @Override
     public void publish(String topic, ExternalEvent event) {
         kafkaTemplate.send(topic, event);
+    }
+
+    public void publishWithAck(ProducerRecord<String, ExternalEvent> record, Acknowledgment ack) {
+        dltKafkaTemplate.send(record).whenComplete((sendResult, exception) -> {
+            if (exception == null) {
+                ack.acknowledge();
+            } else {
+                log.info("카프카 발행 실패로 인한 ack 실패");
+            }
+        });
     }
 }

--- a/draw/src/main/java/ddalkak/draw/service/util/HeaderUtils.java
+++ b/draw/src/main/java/ddalkak/draw/service/util/HeaderUtils.java
@@ -1,0 +1,16 @@
+package ddalkak.draw.service.util;
+
+import java.nio.ByteBuffer;
+
+public class HeaderUtils {
+    public static int toInteger(byte[] origin) {
+        if (origin == null) {
+            return 1;
+        }
+        return ByteBuffer.wrap(origin).getInt();
+    }
+
+    public static byte[] toByteArray(int origin) {
+        return ByteBuffer.allocate(4).putInt(origin).array();
+    }
+}


### PR DESCRIPTION
- Retry 및 Dead Letter Topic 운영으로 원본 토픽의 Head-Of-Line Blocking 최소화
- 지수 백오프를 적용해 원본 -> retry1 -> retry2 ... 전송, MaxAttempts 도달하면 dlt 전송
- Dlt Handler에서 cause exception을 통해 Retryable 판단
- Retryable Exception -> 원본 토픽으로 재전송 (커스텀 헤더로 redrive count 계산, 임계치까지만 반복)
- Non-Retryable Exception & Max Redrive count -> 장애 이벤트 정보 영속화해 분석 