### PR TITLE
[응모 서비스] 경품 서비스에서 재고 차감 실패 시 보상 트랜잭션으로 응모권 롤백

### DIFF
--- a/draw/src/main/java/ddalkak/draw/domain/DrawResult.java
+++ b/draw/src/main/java/ddalkak/draw/domain/DrawResult.java
@@ -3,5 +3,6 @@ package ddalkak.draw.domain;
 public enum DrawResult {
     WIN,
     PENDING,
-    LOSE
+    LOSE,
+    ERROR
 }

--- a/draw/src/main/java/ddalkak/draw/domain/entity/Ticket.java
+++ b/draw/src/main/java/ddalkak/draw/domain/entity/Ticket.java
@@ -36,6 +36,10 @@ public class Ticket extends BaseEntity {
         quantity--;
     }
 
+    public void increase() {
+        quantity++;
+    }
+
     public void rewardDailyLogin(LocalDate today) {
         if (lastLogin == null || !lastLogin.isEqual(today)) {
             quantity++;

--- a/draw/src/main/java/ddalkak/draw/dto/event/DecreaseResult.java
+++ b/draw/src/main/java/ddalkak/draw/dto/event/DecreaseResult.java
@@ -2,5 +2,6 @@ package ddalkak.draw.dto.event;
 
 public enum DecreaseResult {
     SUCCESS,
-    FAILURE
+    FAILURE,
+    ERROR
 }

--- a/draw/src/main/java/ddalkak/draw/dto/event/DecreaseStockEvent.java
+++ b/draw/src/main/java/ddalkak/draw/dto/event/DecreaseStockEvent.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 public record DecreaseStockEvent(long eventId,
                                  Instant occurAt,
                                  long drawId,
+                                 long memberId,
                                  long prizeId,
                                  DecreaseResult result) implements ExternalEvent {
 }

--- a/draw/src/main/java/ddalkak/draw/dto/event/DrawWinEvent.java
+++ b/draw/src/main/java/ddalkak/draw/dto/event/DrawWinEvent.java
@@ -8,12 +8,14 @@ import java.time.Instant;
 @Builder(access = AccessLevel.PRIVATE)
 public record DrawWinEvent(long eventId,
                            long drawId,
+                           long memberId,
                            long prizeId,
                            Instant occurAt) implements ExternalEvent {
-    public static DrawWinEvent of(long eventId, long drawId, long prizeId) {
+    public static DrawWinEvent of(long eventId, long drawId, long memberId, long prizeId) {
         return DrawWinEvent.builder()
                 .eventId(eventId)
                 .drawId(drawId)
+                .memberId(memberId)
                 .prizeId(prizeId)
                 .occurAt(Instant.now())
                 .build();

--- a/draw/src/main/java/ddalkak/draw/service/core/DrawService.java
+++ b/draw/src/main/java/ddalkak/draw/service/core/DrawService.java
@@ -33,7 +33,7 @@ public class DrawService {
         drawRepository.save(draw);
 
         if (draw.isWinPending()) {
-            applicationEventPublisher.publishEvent(DrawWinEvent.of(idGenerator.generate(), draw.getId(), prizeId));
+            applicationEventPublisher.publishEvent(DrawWinEvent.of(idGenerator.generate(), draw.getId(), memberId, prizeId));
         }
     }
 

--- a/draw/src/main/java/ddalkak/draw/service/event/ExternalEventHandler.java
+++ b/draw/src/main/java/ddalkak/draw/service/event/ExternalEventHandler.java
@@ -35,8 +35,11 @@ public class ExternalEventHandler {
     public void handleDecreaseStockEvent(final DecreaseStockEvent event) {
         if (event.result() == DecreaseResult.SUCCESS) {
             drawService.finalizeDrawResult(event.drawId(), DrawResult.WIN);
-        } else {
+        } else if (event.result() == DecreaseResult.FAILURE) {
             drawService.finalizeDrawResult(event.drawId(), DrawResult.LOSE);
+        } else {
+            drawService.finalizeDrawResult(event.drawId(), DrawResult.ERROR);
+            ticketService.increaseTicket(event.memberId());
         }
     }
 }

--- a/draw/src/main/java/ddalkak/draw/service/ticket/TicketService.java
+++ b/draw/src/main/java/ddalkak/draw/service/ticket/TicketService.java
@@ -35,6 +35,13 @@ public class TicketService {
         ticket.rewardDailyLogin(toLocalDate(loginAt));
     }
 
+    @Transactional
+    public void increaseTicket(final long memberId) {
+        Ticket ticket = ticketRepository.findByMemberId(memberId)
+                .orElseThrow();
+        ticket.increase();
+    }
+
     @Transactional(readOnly = true)
     public TicketResponse findTicket(final long memberId) {
         return TicketResponse.of(


### PR DESCRIPTION
- 경품 서비스측은 내부 정책에 의한 retry를 거치고 dlt로 이벤트 기록
- dlt handler는 재고 차감 결과 ERROR로 이벤트 발행
- 응모 서비스는 이벤트 수신 후 응모 결과 ERROR 저장 & 응모권 롤백