### PR TITLE
[상품 서비스] 보상트랜잭션을 위한 이벤트 발행 기능

### DIFF
--- a/prize/src/main/java/ddalkak/prize/domain/entity/PrizeOutbox.java
+++ b/prize/src/main/java/ddalkak/prize/domain/entity/PrizeOutbox.java
@@ -1,6 +1,8 @@
 package ddalkak.prize.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 
 @Entity
@@ -16,12 +18,20 @@ public class PrizeOutbox extends BaseEntity {
     private EventType type;
     @Column(columnDefinition = "JSON")
     private String payload;
-
-    public PrizeOutbox(Long eventId, String payload, EventType eventType) {
+    @Builder(access = AccessLevel.PRIVATE)
+    private PrizeOutbox(Long eventId, String payload, EventType eventType,EventStatus eventStatus) {
         this.eventId = eventId;
         this.status = EventStatus.READY_TO_PUBLISH;
         this.type = eventType;
         this.payload = payload;
+    }
+    public static PrizeOutbox of(Long eventId, String payload, EventType eventType){
+        return PrizeOutbox.builder()
+                .eventId(eventId)
+                .payload(payload)
+                .eventType(eventType)
+                .eventStatus(EventStatus.READY_TO_PUBLISH)
+                .build();
     }
 
     public PrizeOutbox() {

--- a/prize/src/main/java/ddalkak/prize/dto/event/DecreaseResultEvent.java
+++ b/prize/src/main/java/ddalkak/prize/dto/event/DecreaseResultEvent.java
@@ -8,6 +8,7 @@ public record DecreaseResultEvent(
         Long eventId,
         Long prizeId,
         Long drawId,
+        Long memberId,
         DecreaseResult result,
         Instant occurAt
 ) implements ExternalEvent {

--- a/prize/src/main/java/ddalkak/prize/dto/event/DrawWinEvent.java
+++ b/prize/src/main/java/ddalkak/prize/dto/event/DrawWinEvent.java
@@ -6,6 +6,7 @@ public record DrawWinEvent(
         Long eventId,
         Long prizeId,
         Long drawId,
+        Long memberId,
         Instant occurAt
 
 ) implements ExternalEvent {

--- a/prize/src/main/java/ddalkak/prize/dto/event/InternalDecreaseResultEvent.java
+++ b/prize/src/main/java/ddalkak/prize/dto/event/InternalDecreaseResultEvent.java
@@ -1,0 +1,9 @@
+package ddalkak.prize.dto.event;
+
+import org.springframework.kafka.support.Acknowledgment;
+
+public record InternalDecreaseResultEvent(
+        DecreaseResultEvent externalEvent,
+        Acknowledgment ack
+) implements InternalEvent {
+}

--- a/prize/src/main/java/ddalkak/prize/dto/event/InternalEvent.java
+++ b/prize/src/main/java/ddalkak/prize/dto/event/InternalEvent.java
@@ -1,0 +1,5 @@
+package ddalkak.prize.dto.event;
+
+public interface InternalEvent {
+    ExternalEvent externalEvent();
+}

--- a/prize/src/main/java/ddalkak/prize/eventhandler/DecreaseResult.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/DecreaseResult.java
@@ -2,5 +2,6 @@ package ddalkak.prize.eventhandler;
 
 public enum DecreaseResult {
     SUCCESS,
-    FAILURE
+    FAILURE,
+    ERROR
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/DltHandler.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/DltHandler.java
@@ -2,8 +2,10 @@ package ddalkak.prize.eventhandler;
 
 import ddalkak.prize.config.kafka.KafkaConstants;
 import ddalkak.prize.domain.entity.EventType;
+import ddalkak.prize.dto.event.DecreaseResultEvent;
 import ddalkak.prize.dto.event.DrawWinEvent;
 import ddalkak.prize.dto.event.ExternalEvent;
+import ddalkak.prize.dto.event.InternalDecreaseResultEvent;
 import ddalkak.prize.eventhandler.eventpublisher.EventPublisher;
 import ddalkak.prize.service.discardedEvent.DiscardedEventService;
 import ddalkak.prize.service.util.HeaderUtils;
@@ -15,6 +17,7 @@ import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.util.List;
 
 @Component
@@ -24,7 +27,6 @@ public class DltHandler {
     private final List<Class<? extends Throwable>> retryableExceptions;
     private final EventPublisher eventPublisher;
     private final DiscardedEventService discardedEventService;
-
 
     public void handleDltEvents(DrawWinEvent event,
                                 Acknowledgment ack,
@@ -51,8 +53,17 @@ public class DltHandler {
         } else {
             log.info("non retryable ex");
         }
-        discardedEventService.save(EventType.DRAW_WIN ,event, exception, errMsg);
-        ack.acknowledge();
+
+        DecreaseResultEvent decreaseResultEvent = new DecreaseResultEvent(
+                event.eventId(),
+                event.prizeId(),
+                event.drawId(),
+                event.memberId(),
+                DecreaseResult.ERROR,
+                Instant.now()
+        );
+        InternalDecreaseResultEvent internalDecreaseResultEvent = new InternalDecreaseResultEvent(decreaseResultEvent, ack);
+        discardedEventService.save(EventType.DRAW_WIN , internalDecreaseResultEvent, exception, errMsg, ack);
     }
 
     private static boolean isUnderMaxAttempt(int redriveAttempts) {

--- a/prize/src/main/java/ddalkak/prize/eventhandler/EventHandler.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/EventHandler.java
@@ -1,9 +1,10 @@
 package ddalkak.prize.eventhandler;
 
 import ddalkak.prize.dto.event.DrawWinEvent;
+import org.springframework.kafka.support.Acknowledgment;
 
 public interface EventHandler {
-    void handleDecreaseStockEvent(DrawWinEvent event);
+    void handleDecreaseStockEvent(DrawWinEvent event, Acknowledgment ack);
 
 
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/eventlistener/InternalEventHandler.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/eventlistener/InternalEventHandler.java
@@ -1,0 +1,32 @@
+package ddalkak.prize.eventhandler.eventlistener;
+
+import ddalkak.prize.domain.entity.EventType;
+import ddalkak.prize.dto.event.InternalDecreaseResultEvent;
+import ddalkak.prize.eventhandler.eventpublisher.EventPublisher;
+import ddalkak.prize.service.outbox.OutBoxService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class InternalEventHandler {
+    private final OutBoxService outBoxService;
+    private final EventPublisher eventPublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void saveEventOutbox(InternalDecreaseResultEvent event) {
+        log.info("before phase 진입");
+        outBoxService.save(event.externalEvent(), EventType.DECREASE_RESULT);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void publishEvent(InternalDecreaseResultEvent event) {
+        log.info("after phase 진입");
+        eventPublisher.publish(EventType.DECREASE_RESULT.getTopic(), event.externalEvent(), event.ack());
+    }
+
+}

--- a/prize/src/main/java/ddalkak/prize/eventhandler/eventlistener/KafkaConsumer.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/eventlistener/KafkaConsumer.java
@@ -19,10 +19,9 @@ public class KafkaConsumer {
             groupId = "prize-service",
             containerFactory = "kafkaListenerContainerFactory"
     )
-
     public void onMessage(DrawWinEvent event, Acknowledgment ack) {
-          eventHandler.handleDecreaseStockEvent(event);
-          ack.acknowledge();
+          eventHandler.handleDecreaseStockEvent(event,ack);
+
     }
 
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/eventpublisher/EventPublisher.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/eventpublisher/EventPublisher.java
@@ -7,4 +7,5 @@ import org.springframework.kafka.support.Acknowledgment;
 public interface EventPublisher {
     void publish(String topic,ExternalEvent event);
     void publish(ProducerRecord<String,ExternalEvent> record, Acknowledgment ack);
+    void publish(String topic,ExternalEvent event, Acknowledgment ack);
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/eventpublisher/impl/KafkaPublisher.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/eventpublisher/impl/KafkaPublisher.java
@@ -29,4 +29,15 @@ public class KafkaPublisher implements EventPublisher {
             }
         });
     }
+
+    public void publish(String topic, ExternalEvent event, Acknowledgment ack) {
+        kafkaTemplate.send(topic, event)
+                .whenComplete((sendResult, ex) -> {
+                    if (ex == null) {
+                        ack.acknowledge();
+                    } else {
+                        log.info("발행 실패, ack failed");
+                    }
+                });
+    }
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/impl/KafkaEventHandler.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/impl/KafkaEventHandler.java
@@ -2,16 +2,17 @@ package ddalkak.prize.eventhandler.impl;
 
 import ddalkak.prize.aop.annotation.EnableIdempotent;
 import ddalkak.prize.config.error.exception.OutOfStockException;
-import ddalkak.prize.domain.entity.EventType;
 import ddalkak.prize.dto.event.DecreaseResultEvent;
 import ddalkak.prize.dto.event.DrawWinEvent;
+import ddalkak.prize.dto.event.InternalDecreaseResultEvent;
+import ddalkak.prize.dto.event.InternalEvent;
 import ddalkak.prize.eventhandler.DecreaseResult;
 import ddalkak.prize.eventhandler.EventHandler;
-import ddalkak.prize.eventhandler.eventpublisher.EventPublisher;
-import ddalkak.prize.service.outbox.OutBoxService;
 import ddalkak.prize.service.prize.PrizeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,8 +24,7 @@ import java.time.Instant;
 @Component
 public class KafkaEventHandler implements EventHandler {
     private final PrizeService prizeService;
-    private final OutBoxService outBoxService;
-    private final EventPublisher eventPublisher;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * Kafka 에서 상품 재고 감소 이벤트를 수신하여 처리합니다.
@@ -32,9 +32,9 @@ public class KafkaEventHandler implements EventHandler {
      * @param event 상품 재고 감소 이벤트
      */
     @Override
-    @Transactional
     @EnableIdempotent(eventId = "#event.eventId()")
-    public void handleDecreaseStockEvent(DrawWinEvent event) {
+    @Transactional
+    public void handleDecreaseStockEvent(DrawWinEvent event, Acknowledgment ack) {
         log.info("Received event: eventId= {}, prizeId= {}", event.eventId(), event.prizeId());
         // 상품 재고 감소 처리
         try {
@@ -44,16 +44,12 @@ public class KafkaEventHandler implements EventHandler {
                     event.eventId(),
                     event.prizeId(),
                     event.drawId(),
+                    event.memberId(),
                     DecreaseResult.SUCCESS,
                     Instant.now()
             );
-            outBoxService.save(decreaseResultEvent, EventType.DECREASE_RESULT);
-            eventPublisher.publish(EventType.DECREASE_RESULT.getTopic(),new DecreaseResultEvent(
-                    event.eventId(),
-                    event.prizeId(),
-                    event.drawId(),
-                    DecreaseResult.SUCCESS,
-                    Instant.now()));
+            InternalEvent internalEvent = new InternalDecreaseResultEvent(decreaseResultEvent, ack);
+            applicationEventPublisher.publishEvent(internalEvent);
             log.info(String.valueOf(Instant.now()));
 
         } catch (OutOfStockException e) {
@@ -62,17 +58,13 @@ public class KafkaEventHandler implements EventHandler {
                     event.eventId(),
                     event.prizeId(),
                     event.drawId(),
+                    event.memberId(),
                     DecreaseResult.FAILURE,
                     Instant.now()
             );
+            InternalEvent internalEvent = new InternalDecreaseResultEvent(decreaseResultEvent, ack);
+            applicationEventPublisher.publishEvent(internalEvent);
 
-            outBoxService.save(decreaseResultEvent, EventType.DECREASE_RESULT);
-            eventPublisher.publish(EventType.DECREASE_RESULT.getTopic(),new DecreaseResultEvent(
-                    event.eventId(),
-                    event.prizeId(),
-                    event.drawId(),
-                    DecreaseResult.FAILURE,
-                    Instant.now()));
         }
     }
 

--- a/prize/src/main/java/ddalkak/prize/service/discardedEvent/DiscardedEventService.java
+++ b/prize/src/main/java/ddalkak/prize/service/discardedEvent/DiscardedEventService.java
@@ -2,7 +2,10 @@ package ddalkak.prize.service.discardedEvent;
 
 import ddalkak.prize.domain.entity.EventType;
 import ddalkak.prize.dto.event.ExternalEvent;
+import ddalkak.prize.dto.event.InternalEvent;
+import org.springframework.kafka.support.Acknowledgment;
 
 public interface DiscardedEventService {
     void save(EventType eventType , ExternalEvent event, String exception, String errMsg);
+    void save(EventType eventType , InternalEvent event, String exception, String errMsg, Acknowledgment ack);
 }

--- a/prize/src/main/java/ddalkak/prize/service/discardedEvent/impl/DiscardedEventServiceImpl.java
+++ b/prize/src/main/java/ddalkak/prize/service/discardedEvent/impl/DiscardedEventServiceImpl.java
@@ -5,9 +5,12 @@ import ddalkak.prize.aop.annotation.EnableIdempotent;
 import ddalkak.prize.domain.entity.DiscardedEvent;
 import ddalkak.prize.domain.entity.EventType;
 import ddalkak.prize.dto.event.ExternalEvent;
+import ddalkak.prize.dto.event.InternalEvent;
 import ddalkak.prize.repository.discardedEvent.DiscardedEventRepository;
 import ddalkak.prize.service.discardedEvent.DiscardedEventService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,12 +19,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class DiscardedEventServiceImpl implements DiscardedEventService {
     private final DiscardedEventRepository discardedEventRepository;
     private final ObjectMapper objectMapper;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
     @Transactional
     @EnableIdempotent(eventId = "#event.eventId()")
     public void save(EventType eventType, ExternalEvent event, String exception, String errMsg) {
-
         discardedEventRepository.save(
                 DiscardedEvent.of(
                         eventType,
@@ -31,7 +34,21 @@ public class DiscardedEventServiceImpl implements DiscardedEventService {
                         errMsg
                 )
         );
+    }
 
+    @Transactional
+    @EnableIdempotent(eventId = "#event.externalEvent().eventId()")
+    public void save(EventType eventType, InternalEvent event, String exception, String errMsg, Acknowledgment ack) {
+        discardedEventRepository.save(
+                DiscardedEvent.of(
+                        eventType,
+                        event.externalEvent().eventId(),
+                        serialize(event.externalEvent()),
+                        exception,
+                        errMsg
+                )
+        );
+        applicationEventPublisher.publishEvent(event);
     }
 
     private String serialize(ExternalEvent event) {

--- a/prize/src/main/java/ddalkak/prize/service/outbox/impl/OutboxServiceImpl.java
+++ b/prize/src/main/java/ddalkak/prize/service/outbox/impl/OutboxServiceImpl.java
@@ -27,10 +27,8 @@ public class OutboxServiceImpl implements OutBoxService {
     public Long save(ExternalEvent event, EventType eventType) {
 
         String payload = serialize(event);
-        PrizeOutbox prizeOutbox = new PrizeOutbox(event.eventId(), payload, eventType);
-        log.info("Saving event to outbox: {}" , prizeOutbox);
-        PrizeOutbox savedPrizeOutbox = outboxRepository.save(new PrizeOutbox(event.eventId(), payload, eventType));
-
+        PrizeOutbox savedPrizeOutbox = outboxRepository.save(PrizeOutbox.of(event.eventId(), payload, eventType));
+        log.info("Saving event to outbox: {}" , savedPrizeOutbox);
         return savedPrizeOutbox.getId();
 
 


### PR DESCRIPTION

- 응모 비즈니스 로직 실행중 재시도 횟수 초과 || non-retryable exception 이 발생한 경우:
- 1. 애플리케이션 내부 이벤트 발행  -> @TransactionalEventListener로 수신 
- 2. Before-commit 페이즈:  db 아웃박스테이블에 이벤트 정보 저장
- 3. After-commit 페이즈: 회원의 응모권 롤백을 위해 decrease-result 토픽에 ERROR 로 이벤트 발행

+ 정상 흐름시에도  KafkaEventHandler클래스의 ack처리와 카프카 발행, 트랜잭션의 원자성 보장을 위해 마찬가지로 내부 이벤트발행 구조로 변경