### PR TITLE
fix: Kafka 중복메시지 수신시 ack 처리 누락 문제 해결

### DIFF
--- a/prize/src/main/java/ddalkak/prize/dto/event/InternalDecreaseResultEvent.java
+++ b/prize/src/main/java/ddalkak/prize/dto/event/InternalDecreaseResultEvent.java
@@ -3,7 +3,6 @@ package ddalkak.prize.dto.event;
 import org.springframework.kafka.support.Acknowledgment;
 
 public record InternalDecreaseResultEvent(
-        DecreaseResultEvent externalEvent,
-        Acknowledgment ack
+        DecreaseResultEvent externalEvent
 ) implements InternalEvent {
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/EventHandler.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/EventHandler.java
@@ -4,7 +4,7 @@ import ddalkak.prize.dto.event.DrawWinEvent;
 import org.springframework.kafka.support.Acknowledgment;
 
 public interface EventHandler {
-    void handleDecreaseStockEvent(DrawWinEvent event, Acknowledgment ack);
+    void handleDecreaseStockEvent(DrawWinEvent event);
 
 
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/eventlistener/InternalEventHandler.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/eventlistener/InternalEventHandler.java
@@ -26,7 +26,8 @@ public class InternalEventHandler {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void publishEvent(InternalDecreaseResultEvent event) {
         log.info("after phase 진입");
-        eventPublisher.publish(EventType.DECREASE_RESULT.getTopic(), event.externalEvent(), event.ack());
+        eventPublisher.publish(EventType.DECREASE_RESULT.getTopic(), event.externalEvent());
+
     }
 
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/eventlistener/KafkaConsumer.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/eventlistener/KafkaConsumer.java
@@ -20,9 +20,8 @@ public class KafkaConsumer {
             containerFactory = "kafkaListenerContainerFactory"
     )
     public void onMessage(DrawWinEvent event, Acknowledgment ack) {
-          eventHandler.handleDecreaseStockEvent(event,ack);
-
-
+          eventHandler.handleDecreaseStockEvent(event);
+          ack.acknowledge();
     }
 
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/eventpublisher/EventPublisher.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/eventpublisher/EventPublisher.java
@@ -7,5 +7,5 @@ import org.springframework.kafka.support.Acknowledgment;
 public interface EventPublisher {
     void publish(String topic,ExternalEvent event);
     void publish(ProducerRecord<String,ExternalEvent> record, Acknowledgment ack);
-    void publish(String topic,ExternalEvent event, Acknowledgment ack);
+
 }

--- a/prize/src/main/java/ddalkak/prize/eventhandler/impl/KafkaEventHandler.java
+++ b/prize/src/main/java/ddalkak/prize/eventhandler/impl/KafkaEventHandler.java
@@ -34,18 +34,18 @@ public class KafkaEventHandler implements EventHandler {
     @Override
     @EnableIdempotent(eventId = "#event.eventId()")
     @Transactional
-    public void handleDecreaseStockEvent(DrawWinEvent event, Acknowledgment ack) {
+    public void handleDecreaseStockEvent(DrawWinEvent event) {
         log.info("Received event: eventId= {}, prizeId= {}", event.eventId(), event.prizeId());
         // 상품 재고 감소 처리
         try {
             prizeService.decreaseStock(event.prizeId());
             // Outbox에 이벤트 저장
-            InternalEvent internalEvent = new InternalDecreaseResultEvent(DecreaseResultEvent.of(event, DecreaseResult.SUCCESS), ack);
+            InternalEvent internalEvent = new InternalDecreaseResultEvent(DecreaseResultEvent.of(event, DecreaseResult.SUCCESS));
             applicationEventPublisher.publishEvent(internalEvent);
             log.info(String.valueOf(Instant.now()));
         } catch (OutOfStockException e) {
             log.warn("Failed to decrease stock for eventId= {}, prizeId= {}", event.eventId(), event.prizeId());
-            InternalEvent internalEvent = new InternalDecreaseResultEvent(DecreaseResultEvent.of(event, DecreaseResult.FAILURE), ack);
+            InternalEvent internalEvent = new InternalDecreaseResultEvent(DecreaseResultEvent.of(event, DecreaseResult.FAILURE));
             applicationEventPublisher.publishEvent(internalEvent);
         }
     }


### PR DESCRIPTION
- 원인: 기존 ack 처리 위치가 내부 이벤트 핸들러 -> 중복 메시지 수신시 ack 처리 안됨.
- 해결: ack 처리 위치를 KafkaConsumer onMessage메서드로 변경
